### PR TITLE
Improve toHaveClassName message language

### DIFF
--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toHaveClassName--tests.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toHaveClassName--tests.js.snap
@@ -6,7 +6,7 @@ Object {
 }
 `;
 
-exports[`toHaveClassName mount returns the message with the proper fail verbage (mount) 1`] = `"Expected <span> not to contain \\".bar\\" for it's classname"`;
+exports[`toHaveClassName mount returns the message with the proper fail verbage (mount) 1`] = `"Expected <span> not to contain \\".bar\\" in its className"`;
 
 exports[`toHaveClassName mount returns the message with the proper pass verbage (mount) 1`] = `"Expected <span> to have className of \\".bar\\" but instead found \\"bar baz\\""`;
 
@@ -19,7 +19,7 @@ Object {
 ",
   },
   "message": "Expected <2 span nodes found> to have className of \\".baux\\" but instead found \\"baux\\"",
-  "negatedMessage": "Expected <2 span nodes found> not to contain \\".baux\\" for it's classname",
+  "negatedMessage": "Expected <2 span nodes found> not to contain \\".baux\\" in its className",
   "pass": true,
 }
 `;
@@ -30,7 +30,7 @@ Object {
 }
 `;
 
-exports[`toHaveClassName shallow returns the message with the proper fail verbage (shallow) 1`] = `"Expected <span> not to contain \\".bar\\" for it's classname"`;
+exports[`toHaveClassName shallow returns the message with the proper fail verbage (shallow) 1`] = `"Expected <span> not to contain \\".bar\\" in its className"`;
 
 exports[`toHaveClassName shallow returns the message with the proper pass verbage (shallow) 1`] = `"Expected <span> to have className of \\".bar\\" but instead found \\"bar baz\\""`;
 
@@ -43,7 +43,7 @@ Object {
 ",
   },
   "message": "Expected <2 span nodes found> to have className of \\".baux\\" but instead found \\"baux\\"",
-  "negatedMessage": "Expected <2 span nodes found> not to contain \\".baux\\" for it's classname",
+  "negatedMessage": "Expected <2 span nodes found> not to contain \\".baux\\" in its className",
   "pass": true,
 }
 `;

--- a/packages/enzyme-matchers/src/assertions/toHaveClassName.js
+++ b/packages/enzyme-matchers/src/assertions/toHaveClassName.js
@@ -50,7 +50,7 @@ export default function toHaveClassName(
     )}> to have className of "${normalizedClassName}" but instead found "${actualClassName}"`, // eslint-disable-line max-len
     negatedMessage: `Expected <${name(
       enzymeWrapper
-    )}> not to contain "${normalizedClassName}" for it's classname`, // eslint-disable-line max-len
+    )}> not to contain "${normalizedClassName}" in its className`,
     contextualInformation: {
       actual: `Found node output: ${html(enzymeWrapper)}`,
     },


### PR DESCRIPTION
Two tiny things:

1. Corrects possessive "it's" to "its".
2. Changes "classnames" to "classNames"—this is the only place in the repo where "classnames" is treated as a compound word. I thought about using "class names", but "classNames" is used in other output.