### PR TITLE
This compares the objects properly in toMatchElement

### DIFF
--- a/packages/enzyme-matchers/src/assertions/toMatchElement.js
+++ b/packages/enzyme-matchers/src/assertions/toMatchElement.js
@@ -25,7 +25,7 @@ function toMatchElement(
 
   const actual = actualEnzymeWrapper.debug(options);
   const expected = expectedWrapper.debug(options);
-  const pass = actual === expected;
+  const pass = actual.equals(expected);
 
   return {
     pass,


### PR DESCRIPTION
This compares the objects properly, rather than just equating the reference