### PR TITLE
Allow styles, props, and state to be compared via objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,19 +29,19 @@ This library supports several testing frameworks including [Jest](https://github
 * [toBeEmpty()](#tobeempty)
 * [toBeEmptyRender()](#tobeemptyrender)
 * [toBePresent()](#tobepresent)
-* [toContainReact()](#tocontainreactreactinstanceobject)
-* [toHaveClassName()](#tohaveclassnameclassnamestring)
-* [toHaveHTML()](#tohavehtmlhtmlstring)
-* [toHaveProp()](#tohaveproppropkeystring-propvalueany)
-* [toHaveRef()](#tohaverefrefnamestring)
-* [toHaveState()](#tohavestatestatekeystring-statevalueany)
-* [toHaveStyle()](#tohavestylestylekeystring-stylevalueany)
-* [toHaveTagName()](#tohavetagnametagnamestring)
-* [toHaveText()](#tohavetexttextstring)
-* [toIncludeText()](#toincludetexttextstring)
-* [toHaveValue()](#tohavevaluevalueany)
-* [toMatchElement()](#tomatchelementreactinstanceobject-optionsany)
-* [toMatchSelector()](#tomatchselectorselectorstring)
+* [toContainReact()](#tocontainreact)
+* [toHaveClassName()](#tohaveclassname)
+* [toHaveHTML()](#tohavehtml)
+* [toHaveProp()](#tohaveprop-propvalueany)
+* [toHaveRef()](#tohaverefref)
+* [toHaveState()](#tohavestate)
+* [toHaveStyle()](#tohavestyle)
+* [toHaveTagName()](#tohavetagname)
+* [toHaveText()](#tohavetext)
+* [toIncludeText()](#toincludetext)
+* [toHaveValue()](#tohavevalue)
+* [toMatchElement()](#tomatchelement)
+* [toMatchSelector()](#tomatchselector)
 
 _Other_
 
@@ -54,6 +54,12 @@ _Other_
 | render | mount | shallow |
 | -------|-------|-------- |
 | no     | yes   | yes     |
+
+Ways to use this API:
+
+```js
+expect().toBeChecked();
+```
 
 Assert that the given wrapper is checked:
 
@@ -83,6 +89,12 @@ expect(wrapper.find('#not')).not.toBeChecked();
 | -------|-------|-------- |
 | no     | yes   | yes     |
 
+Ways to use this API:
+
+```js
+expect().toBeDisabled();
+```
+
 Assert that the given wrapper is disabled:
 
 ```js
@@ -110,6 +122,12 @@ expect(wrapper.find('#not')).not.toBeDisabled();
 | -------|-------|-------- |
 | no     | yes   | yes     |
 
+Ways to use this API:
+
+```js
+expect().toBeEmpty();
+```
+
 Assert that the given wrapper is empty:
 
 ```js
@@ -133,6 +151,12 @@ expect(wrapper.find('span')).not.toBeEmpty();
 | render | mount | shallow |
 | -------|-------|-------- |
 | no     | yes   | yes     |
+
+Ways to use this API:
+
+```js
+expect().toBeEmptyRender();
+```
 
 Assert that the given wrapper has an empty render (`null` or `false`):
 
@@ -161,6 +185,12 @@ expect(wrapper).not.toBeEmptyRender();
 | -------|-------|-------- |
 | no     | yes   | yes     |
 
+Ways to use this API:
+
+```js
+expect().toBePresent();
+```
+
 Opposite of [`toBeEmpty()`](#toBeEmpty). Assert that the given wrapper has children of any length:
 
 ```js
@@ -179,11 +209,17 @@ expect(wrapper.find('span')).toBePresent();
 expect(wrapper.find('ul')).not.toBePresent();
 ```
 
-#### `toContainReact(reactInstance:Object)`
+#### `toContainReact()`
 
 | render | mount | shallow |
 | -------|-------|-------- |
 | no     | yes   | yes     |
+
+Ways to use this API:
+
+```js
+expect().toHaveContainReact(<div>foo</div>);
+```
 
 Assert that the given wrapper contains the provided react instance:
 
@@ -219,11 +255,17 @@ expect(wrapper).toContainReact(<User index={1} />);
 expect(wrapper).not.toContainReact(<User index={9000} />);
 ```
 
-#### `toHaveClassName(className:string)`
+#### `toHaveClassName()`
 
 | render | mount | shallow |
 | -------|-------|-------- |
 | no     | yes   | yes     |
+
+Ways to use this API:
+
+```js
+expect().toHaveClassName('foo');
+```
 
 Assert that the given wrapper has the provided className:
 
@@ -246,11 +288,18 @@ expect(wrapper.find('.bar')).toHaveClassName('bar baz');
 expect(wrapper.find('.bar')).toHaveClassName('baz');
 ```
 
-#### `toHaveHTML(html:string)`
+#### `toHaveHTML()`
 
 | render | mount | shallow |
 | -------|-------|-------- |
 | no     | yes   | yes     |
+
+Ways to use this API:
+
+```js
+expect().toHaveHTML('<div>html</div>');
+```
+
 
 Assert that the given wrapper has the provided html:
 
@@ -272,11 +321,19 @@ expect(wrapper.find('#child')).toHaveHTML(
 );
 ```
 
-#### `toHaveProp(propKey:string[, propValue:?any])`
+#### `toHaveProp()`
 
 | render | mount | shallow |
 | -------|-------|-------- |
 | no     | yes   | yes     |
+
+Ways to use this API:
+
+```js
+expect().toHaveProp('key', 'value');
+expect().toHaveProp('key');
+expect().toHaveProp({key: 'value'});
+```
 
 Assert that the given wrapper has the provided propKey and associated value if specified:
 
@@ -302,13 +359,24 @@ expect(wrapper.find(User)).toHaveProp('foo', 'baz');
 
 expect(wrapper.find(User)).toHaveProp('bar');
 expect(wrapper.find(User)).toHaveProp('bar', [1,2,3]);
+
+expect(wrapper.find(User)).toHaveProp({
+  bar: [1, 2, 3],
+  foo: 'baz',
+});
 ```
 
-#### `toHaveRef(refName:string)`
+#### `toHaveRef()`
 
 | render | mount | shallow |
 | -------|-------|-------- |
 | no     | yes   | no      |
+
+Ways to use this API:
+
+```js
+expect().toHaveRef('foo');
+```
 
 Assert that the mounted wrapper has the provided ref:
 
@@ -329,11 +397,19 @@ expect(wrapper).toHaveRef('child');
 expect(wrapper).not.toHaveRef('foo');
 ```
 
-#### `toHaveState(stateKey:string[, stateValue:?any])`
+#### `toHaveState()`
 
 | render | mount | shallow |
 | -------|-------|-------- |
 | no     | yes   | yes     |
+
+Ways to use this API:
+
+```js
+expect().toHaveState('foo');
+expect().toHaveState('foo', 'bar');
+expect().toHaveState({ foo: 'bar' });
+```
 
 Assert that the component has the provided stateKey and optional value if specified:
 
@@ -357,13 +433,22 @@ const wrapper = mount(<Fixture />); // mount/render/shallow when applicable
 
 expect(wrapper).toHaveState('foo');
 expect(wrapper).toHaveState('foo', false);
+expect(wrapper).toHaveState({ foo: false });
 ```
 
-#### `toHaveStyle(styleKey:string[, styleValue:?any])`
+#### `toHaveStyle()`
 
 | render | mount | shallow |
 | -------|-------|-------- |
 | no     | yes   | yes     |
+
+Ways to use this API:
+
+```js
+expect().toHaveStyle('height');
+expect().toHaveStyle('height', '100%');
+expect().toHaveStyle({ height: '100%' });
+```
 
 Assert that the component has style of the provided key and value:
 
@@ -386,11 +471,17 @@ expect(wrapper.find('#style1')).toHaveStyle('height', '100%');
 expect(wrapper.find('#style2')).toHaveStyle('flex', 8);
 ```
 
-#### `toHaveTagName(tagName:string)`
+#### `toHaveTagName()`
 
 | render | mount | shallow |
 | -------|-------|-------- |
 | no     | yes   | yes     |
+
+Ways to use this API:
+
+```js
+expect().toHaveTagName('div');
+```
 
 Assert that the wrapper is of a certain tag type:
 
@@ -409,11 +500,17 @@ expect(wrapper.find('#span')).toHaveTagName('span');
 expect(wrapper.find('#span')).not.toHaveTagName('div');
 ```
 
-#### `toHaveText(text:string)`
+#### `toHaveText()`
 
 | render | mount | shallow |
 | -------|-------|-------- |
 | no     | yes   | yes     |
+
+Ways to use this API:
+
+```js
+expect().toHaveText('bar');
+```
 
 Assert that the wrapper's text matches the provided text exactly, using a strict comparison (`===`).
 
@@ -436,11 +533,17 @@ expect(wrapper.find('#full')).toHaveText();
 expect(wrapper.find('#empty')).not.toHaveText();
 ```
 
-#### `toIncludeText(text:string)`
+#### `toIncludeText()`
 
 | render | mount | shallow |
 | -------|-------|-------- |
 | no     | yes   | yes     |
+
+Ways to use this API:
+
+```js
+expect().toIncludeText('bar');
+```
 
 Assert that the wrapper includes the provided text:
 
@@ -459,11 +562,17 @@ expect(wrapper.find('#full')).toIncludeText('important');
 expect(wrapper.find('#full')).not.toIncludeText('Wrong');
 ```
 
-#### `toHaveValue(value:any)`
+#### `toHaveValue()`
 
 | render | mount | shallow |
 | -------|-------|-------- |
 | no     | yes   | yes     |
+
+Ways to use this API:
+
+```js
+expect().toHaveValue('bar');
+```
 
 Assert that the given wrapper has the provided `value`:
 
@@ -483,11 +592,18 @@ expect(wrapper.find('input').at(0)).toHaveValue('test');
 expect(wrapper.find('input').at(1)).toHaveValue('bar');
 ```
 
-#### `toMatchElement(reactInstance:Object, options:any)`
+#### `toMatchElement()`
 
 | render | mount | shallow |
 | -------|-------|-------- |
 | no     | yes   | yes     |
+
+Ways to use this API:
+
+```js
+expect().toMatchSelector(<Foo />);
+expect().toMatchSelector(<Foo />, { ignoreProps: false });
+```
 
 Assert the wrapper matches the provided react instance. This is a matcher form of Enzyme's wrapper.matchesElement(), which returns a bool with no indication of what caused a failed match. This matcher includes the actual and expected debug trees as contextual information when it fails. Like matchesElement(), props are ignored. If you want to compare prop values as well, pass `{ ignoreProps: false }` as options. Uses enzyme's [debug()](http://airbnb.io/enzyme/docs/api/ShallowWrapper/debug.html) under the hood and compares debug strings, which makes for a human readable diff when expects fail.
 
@@ -513,11 +629,17 @@ expect(wrapper.find('span')).toMatchElement(
 expect(wrapper).not.toMatchElement(<div />);
 ```
 
-#### `toMatchSelector(selector:string)`
+#### `toMatchSelector()`
 
 | render | mount | shallow |
 | -------|-------|-------- |
 | no     | yes   | yes     |
+
+Ways to use this API:
+
+```js
+expect().toMatchSelector('.foo');
+```
 
 Assert that the wrapper matches the provided `selector`:
 

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toHaveProp--tests.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toHaveProp--tests.js.snap
@@ -2,12 +2,12 @@
 
 exports[`toHaveProp mount provides contextual information for the message (mount) 1`] = `
 Object {
-  "actual": "Actual: [33marrayProp[39m[90m:[39m [33m[90m[90m[[90m
+  "actual": "Actual props: [33marrayProp[39m[90m:[39m [33m[90m[90m[[90m
   [34m1[90m
   [34m2[90m
   [34m3[90m
 [90m][90m[33m[39m",
-  "expected": "Expected: [33marrayProp[39m[90m:[39m [33m[90m[90m[[90m
+  "expected": "Expected props: [33marrayProp[39m[90m:[39m [33m[90m[90m[[90m
   [34m1[90m
   [34m2[90m
   [34m3[90m
@@ -15,18 +15,18 @@ Object {
 }
 `;
 
-exports[`toHaveProp mount returns the message with the proper fail verbage (mount) 1`] = `"Expected <User> \\"arrayProp\\" prop values not to match, but they did."`;
+exports[`toHaveProp mount returns the message with the proper fail verbage (mount) 1`] = `"Expected <User> \\"\\" prop values not to match, but they did."`;
 
-exports[`toHaveProp mount returns the message with the proper pass verbage (mount) 1`] = `"Expected <User> \\"arrayProp\\" prop values to match but they didn't."`;
+exports[`toHaveProp mount returns the message with the proper pass verbage (mount) 1`] = `"Expected <User> \\"\\" prop values to match but they didn't."`;
 
 exports[`toHaveProp shallow provides contextual information for the message (shallow) 1`] = `
 Object {
-  "actual": "Actual: [33marrayProp[39m[90m:[39m [33m[90m[90m[[90m
+  "actual": "Actual props: [33marrayProp[39m[90m:[39m [33m[90m[90m[[90m
   [34m1[90m
   [34m2[90m
   [34m3[90m
 [90m][90m[33m[39m",
-  "expected": "Expected: [33marrayProp[39m[90m:[39m [33m[90m[90m[[90m
+  "expected": "Expected props: [33marrayProp[39m[90m:[39m [33m[90m[90m[[90m
   [34m1[90m
   [34m2[90m
   [34m3[90m
@@ -34,6 +34,6 @@ Object {
 }
 `;
 
-exports[`toHaveProp shallow returns the message with the proper fail verbage (shallow) 1`] = `"Expected <User> \\"arrayProp\\" prop values not to match, but they did."`;
+exports[`toHaveProp shallow returns the message with the proper fail verbage (shallow) 1`] = `"Expected <User> \\"\\" prop values not to match, but they did."`;
 
-exports[`toHaveProp shallow returns the message with the proper pass verbage (shallow) 1`] = `"Expected <User> \\"arrayProp\\" prop values to match but they didn't."`;
+exports[`toHaveProp shallow returns the message with the proper pass verbage (shallow) 1`] = `"Expected <User> \\"\\" prop values to match but they didn't."`;

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toHaveState--tests.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toHaveState--tests.js.snap
@@ -2,7 +2,7 @@
 
 exports[`toHaveState mount provides contextual information for the message (mount) 1`] = `
 Object {
-  "actual": "Actual [33marray[39m[90m:[39m [33m[90m[90m[[90m
+  "actual": "Actual state: [33marray[39m[90m:[39m [33m[90m[90m[[90m
   [34m1[90m
   [34m2[90m
   [34m3[90m
@@ -15,13 +15,13 @@ Object {
 }
 `;
 
-exports[`toHaveState mount returns the message with the proper fail verbage (mount) 1`] = `"Expected <Fixture> component state values to be different for key \\"array\\" but they didn't."`;
+exports[`toHaveState mount returns the message with the proper fail verbage (mount) 1`] = `"Expected <Fixture> component state values to be different for keys \\"\\" but they didn't."`;
 
-exports[`toHaveState mount returns the message with the proper pass verbage (mount) 1`] = `"Expected <Fixture> component state values to match for key \\"array\\" but they didn't."`;
+exports[`toHaveState mount returns the message with the proper pass verbage (mount) 1`] = `"Expected <Fixture> component state values to match for keys \\"\\" but they didn't."`;
 
 exports[`toHaveState shallow provides contextual information for the message (shallow) 1`] = `
 Object {
-  "actual": "Actual [33marray[39m[90m:[39m [33m[90m[90m[[90m
+  "actual": "Actual state: [33marray[39m[90m:[39m [33m[90m[90m[[90m
   [34m1[90m
   [34m2[90m
   [34m3[90m
@@ -34,6 +34,6 @@ Object {
 }
 `;
 
-exports[`toHaveState shallow returns the message with the proper fail verbage (shallow) 1`] = `"Expected <div> component state values to be different for key \\"array\\" but they didn't."`;
+exports[`toHaveState shallow returns the message with the proper fail verbage (shallow) 1`] = `"Expected <div> component state values to be different for keys \\"\\" but they didn't."`;
 
-exports[`toHaveState shallow returns the message with the proper pass verbage (shallow) 1`] = `"Expected <div> component state values to match for key \\"array\\" but they didn't."`;
+exports[`toHaveState shallow returns the message with the proper pass verbage (shallow) 1`] = `"Expected <div> component state values to match for keys \\"\\" but they didn't."`;

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toHaveStyle--tests.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toHaveStyle--tests.js.snap
@@ -2,8 +2,8 @@
 
 exports[`toHaveStyle mount provides contextual information for the message (mount) 1`] = `
 Object {
-  "actual": "Actual: [33mheight[39m[90m:[39m [33m[90m\\"100%\\"[33m[39m",
-  "expected": "Expected: [33mheight[39m[90m:[39m [33m[90m\\"100%\\"[33m[39m",
+  "actual": "Actual style: [33mheight[39m[90m:[39m [33m[90m\\"100%\\"[33m[39m",
+  "expected": "Expected style: [33mheight[39m[90m:[39m [33m[90m\\"100%\\"[33m[39m",
 }
 `;
 
@@ -23,20 +23,20 @@ Object {
   "contextualInformation": Object {
     "actual": "<div style=\\"width: 0px;\\"></div>",
   },
-  "message": "Expected <div> component to have a style key of \\"height\\" but it did not.",
+  "message": "Expected <div> component to have a style keys of \\"height\\" but it did not.",
   "negatedMessage": "Expected <div> component not to have a style key of \\"height\\" but it did.",
   "pass": false,
 }
 `;
 
-exports[`toHaveStyle mount returns the message with the proper fail verbage (mount) 1`] = `"Expected <span> component style values to be different for key \\"height\\", but they weren't"`;
+exports[`toHaveStyle mount returns the message with the proper fail verbage (mount) 1`] = `"Expected <span> component style values to be different for key \\"\\", but they weren't"`;
 
-exports[`toHaveStyle mount returns the message with the proper pass verbage (mount) 1`] = `"Expected <span> component style values to match for key \\"height\\", but they didn't"`;
+exports[`toHaveStyle mount returns the message with the proper pass verbage (mount) 1`] = `"Expected <span> component style values to match for key \\"\\", but they didn't"`;
 
 exports[`toHaveStyle shallow provides contextual information for the message (shallow) 1`] = `
 Object {
-  "actual": "Actual: [33mheight[39m[90m:[39m [33m[90m\\"100%\\"[33m[39m",
-  "expected": "Expected: [33mheight[39m[90m:[39m [33m[90m\\"100%\\"[33m[39m",
+  "actual": "Actual style: [33mheight[39m[90m:[39m [33m[90m\\"100%\\"[33m[39m",
+  "expected": "Expected style: [33mheight[39m[90m:[39m [33m[90m\\"100%\\"[33m[39m",
 }
 `;
 
@@ -56,12 +56,12 @@ Object {
   "contextualInformation": Object {
     "actual": "<div style={{...}} />",
   },
-  "message": "Expected <div> component to have a style key of \\"height\\" but it did not.",
+  "message": "Expected <div> component to have a style keys of \\"height\\" but it did not.",
   "negatedMessage": "Expected <div> component not to have a style key of \\"height\\" but it did.",
   "pass": false,
 }
 `;
 
-exports[`toHaveStyle shallow returns the message with the proper fail verbage (shallow) 1`] = `"Expected <span> component style values to be different for key \\"height\\", but they weren't"`;
+exports[`toHaveStyle shallow returns the message with the proper fail verbage (shallow) 1`] = `"Expected <span> component style values to be different for key \\"\\", but they weren't"`;
 
-exports[`toHaveStyle shallow returns the message with the proper pass verbage (shallow) 1`] = `"Expected <span> component style values to match for key \\"height\\", but they didn't"`;
+exports[`toHaveStyle shallow returns the message with the proper pass verbage (shallow) 1`] = `"Expected <span> component style values to match for key \\"\\", but they didn't"`;

--- a/packages/enzyme-matchers/src/assertions/__tests__/toHaveState--tests.js
+++ b/packages/enzyme-matchers/src/assertions/__tests__/toHaveState--tests.js
@@ -103,6 +103,22 @@ describe('toHaveState', () => {
 
         expect(falsy.pass).toBeFalsy();
       });
+
+      it('should support object arguments', () => {
+        const wrapper = builder(<Fixture />);
+
+        const passResult = toHaveState(wrapper, {
+          foo: false,
+          array: [1, 2, 3],
+        });
+        const failResult = toHaveState(wrapper, {
+          foo: true,
+          array: [1, 2, 3],
+        });
+
+        expect(passResult.pass).toBeTruthy();
+        expect(failResult.pass).toBeFalsy();
+      });
     });
   });
 });

--- a/packages/enzyme-matchers/src/assertions/__tests__/toHaveStyle--tests.js
+++ b/packages/enzyme-matchers/src/assertions/__tests__/toHaveStyle--tests.js
@@ -51,6 +51,24 @@ describe('toHaveStyle', () => {
 
         expect(nfalsyResults).toMatchSnapshot();
       });
+
+      it('should support object arguments', () => {
+        const style = { backgroundColor: '#000', width: 10, display: 'none' };
+
+        const wrapper = builder(<div style={style} />);
+
+        const passResult = toHaveStyle(wrapper, {
+          backgroundColor: '#000',
+          width: 10,
+        });
+        const failResult = toHaveStyle(wrapper, {
+          backgroundColor: '#000',
+          display: 'block',
+        });
+
+        expect(passResult.pass).toBeTruthy();
+        expect(failResult.pass).toBeFalsy();
+      });
     });
 
     describe(`${builder.name} - array of styles`, () => {
@@ -105,6 +123,24 @@ describe('toHaveStyle', () => {
 
         expect(widthResult.pass).toBeTruthy();
         expect(heightResult.pass).toBeTruthy();
+      });
+
+      it('should support object arguments', () => {
+        const style = { backgroundColor: '#000', width: 10, display: 'none' };
+
+        const wrapper = builder(<div style={style} />);
+
+        const passResult = toHaveStyle(wrapper, {
+          backgroundColor: '#000',
+          width: 10,
+        });
+        const failResult = toHaveStyle(wrapper, {
+          backgroundColor: '#000',
+          display: 'block',
+        });
+
+        expect(passResult.pass).toBeTruthy();
+        expect(failResult.pass).toBeFalsy();
       });
     });
   });

--- a/packages/enzyme-matchers/src/types/ObjectReductionResponse.js
+++ b/packages/enzyme-matchers/src/types/ObjectReductionResponse.js
@@ -1,0 +1,15 @@
+/**
+ * This source code is licensed under the MIT-style license found in the
+ * LICENSE file in the root directory of this source tree. *
+ *
+ * @providesModule ObjectReductionResponse
+ * @flow
+ */
+
+export type ObjectReductionResponse = {
+  actual: { [key: string]: any },
+  expected: { [key: string]: any },
+  pass: boolean,
+  missingKeys: Array<string>,
+  unmatchedKeys: array<string>,
+};

--- a/packages/enzyme-matchers/src/types/index.js
+++ b/packages/enzyme-matchers/src/types/index.js
@@ -4,4 +4,5 @@ export type { Assertion } from './Assertion';
 export type { EnzymeObject } from './EnzymeObject';
 export type { Matcher } from './Matcher';
 export type { MatcherMethods } from './MatcherMethods';
+export type { ObjectReductionResponse } from './ObjectReductionResponse';
 export type { ToMatchElementOptions } from './ToMatchElementOptions';

--- a/packages/enzyme-matchers/src/utils/__tests__/reduceAssertionObject.test.js
+++ b/packages/enzyme-matchers/src/utils/__tests__/reduceAssertionObject.test.js
@@ -1,0 +1,85 @@
+import reduceAssertionObject from '../reduceAssertionObject';
+
+const _this = { equals: (a, b) => a === b };
+
+describe('reduceAssertionObject', () => {
+  it('passes true if equal match', () => {
+    const compDetails = { foo: true, bar: false };
+    const matchDetails = { foo: true, bar: false };
+
+    const results = reduceAssertionObject.call(
+      _this,
+      compDetails,
+      matchDetails
+    );
+
+    expect(results.pass).toBeTruthy();
+    expect(results.actual).toEqual(compDetails);
+    expect(results.expected).toEqual(matchDetails);
+    expect(results.missingKeys).toEqual([]);
+    expect(results.unmatchedKeys).toEqual([]);
+  });
+
+  it('passes true if key,value equal match', () => {
+    const compDetails = { foo: true, bar: false };
+
+    const results = reduceAssertionObject.call(_this, compDetails, 'foo', true);
+
+    expect(results.pass).toBeTruthy();
+    expect(results.actual).toEqual({ foo: true });
+    expect(results.expected).toEqual({ foo: true });
+    expect(results.missingKeys).toEqual([]);
+    expect(results.unmatchedKeys).toEqual([]);
+  });
+
+  it('passes false when one key mismatches', () => {
+    const compDetails = { foo: true, bar: false };
+    const matchDetails = { foo: true, bar: true };
+
+    const results = reduceAssertionObject.call(
+      _this,
+      compDetails,
+      matchDetails
+    );
+
+    expect(results.pass).toBeFalsy();
+    expect(results.actual).toEqual(compDetails);
+    expect(results.expected).toEqual(matchDetails);
+    expect(results.missingKeys).toEqual([]);
+    expect(results.unmatchedKeys).toEqual(['bar']);
+  });
+
+  it('passes false when one key mismatches', () => {
+    const compDetails = { foo: true, bar: false };
+    const matchDetails = { foo: true, bar: true };
+
+    const results = reduceAssertionObject.call(
+      _this,
+      compDetails,
+      matchDetails
+    );
+
+    expect(results.pass).toBeFalsy();
+    expect(results.actual).toEqual(compDetails);
+    expect(results.expected).toEqual(matchDetails);
+    expect(results.missingKeys).toEqual([]);
+    expect(results.unmatchedKeys).toEqual(['bar']);
+  });
+
+  it('passes false when an extra key is provided', () => {
+    const compDetails = { foo: true };
+    const matchDetails = { foo: true, bar: true };
+
+    const results = reduceAssertionObject.call(
+      _this,
+      compDetails,
+      matchDetails
+    );
+
+    expect(results.pass).toBeFalsy();
+    expect(results.actual).toEqual(compDetails);
+    expect(results.expected).toEqual(matchDetails);
+    expect(results.missingKeys).toEqual(['bar']);
+    expect(results.unmatchedKeys).toEqual([]);
+  });
+});

--- a/packages/enzyme-matchers/src/utils/reduceAssertionObject.js
+++ b/packages/enzyme-matchers/src/utils/reduceAssertionObject.js
@@ -1,0 +1,63 @@
+/*
+ * @flow
+ */
+
+import deepEqualIdent from 'deep-equal-ident';
+import { ObjectReductionResponse } from '../types';
+
+type ObjectKey = Object | string;
+
+export default function reduceAssertionObject(
+  componentDetails: Object,
+  objectOrKey: ObjectKey,
+  potentialValue?: any
+): ObjectReductionResponse {
+  const matcherDetails =
+    typeof objectOrKey === 'object' && !Array.isArray(objectOrKey)
+      ? objectOrKey
+      : { [objectOrKey]: potentialValue };
+
+  const equals = this && this.equals ? this.equals : deepEqualIdent;
+
+  return Object.keys(matcherDetails).reduce(
+    (retVal, key) => {
+      const match = equals(componentDetails[key], matcherDetails[key]);
+      retVal.actual[key] = componentDetails[key];
+      retVal.expected[key] = matcherDetails[key];
+
+      /*
+       * This check helps us give better error messages when the componentDetails doesnt
+       * include a specific key at all.
+       */
+      if (!componentDetails.hasOwnProperty(key)) {
+        retVal.missingKeys.push(key);
+        retVal.pass = false;
+        return retVal;
+      }
+
+      /*
+       * This is just a list of anything that fails to match.
+       */
+      if (!match) {
+        retVal.unmatchedKeys.push(key);
+      }
+
+      /*
+       * We only want to update if it was previous pass.
+       * If one fails, its all a fail
+       */
+      if (retVal.pass) {
+        retVal.pass = match;
+      }
+
+      return retVal;
+    },
+    {
+      actual: {},
+      expected: {},
+      pass: true,
+      missingKeys: [],
+      unmatchedKeys: [],
+    }
+  );
+}

--- a/packages/jest-enzyme/src/__failing_tests__/toBeChecked.test.js
+++ b/packages/jest-enzyme/src/__failing_tests__/toBeChecked.test.js
@@ -2,7 +2,7 @@ const { shallow, mount } = require('enzyme');
 const React = require('react');
 const PropTypes = require('prop-types');
 
-describe.only('failing test', () => {
+describe('failing test', () => {
   [shallow, mount].forEach(builder => {
     describe(builder.name, () => {
       const Fixture = props => <input defaultChecked={props.defaultChecked} />;
@@ -19,7 +19,7 @@ describe.only('failing test', () => {
         ).not.toBeChecked();
       });
 
-      fit('non-enzyme data', () => {
+      it('non-enzyme data', () => {
         expect([]).toBeChecked();
       });
     });

--- a/packages/jest-enzyme/src/__failing_tests__/toHaveState.test.js
+++ b/packages/jest-enzyme/src/__failing_tests__/toHaveState.test.js
@@ -3,9 +3,12 @@ const React = require('react');
 
 describe('failing test', () => {
   class Fixture extends React.Component {
-    state = {
-      foo: true,
-    };
+    constructor() {
+      super();
+      this.state = {
+        foo: true,
+      };
+    }
     render() {
       return (
         <div disabled>


### PR DESCRIPTION
Allows `toHaveStyle`, `toHaveProp`, `toHaveState` matcher to accept an object instead of a key, value args.

#171 