### PR TITLE
Add toBeEmptyRender matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This library supports several testing frameworks including [Jest](https://github
 * [toBeChecked()](#tobechecked)
 * [toBeDisabled()](#tobedisabled)
 * [toBeEmpty()](#tobeempty)
+* [toBeEmptyRender()](#tobeemptyrender)
 * [toBePresent()](#tobepresent)
 * [toContainReact()](#tocontainreactreactinstanceobject)
 * [toHaveClassName()](#tohaveclassnameclassnamestring)
@@ -125,6 +126,33 @@ const wrapper = mount(<Fixture />); // mount/render/shallow when applicable
 
 expect(wrapper.find('ul')).toBeEmpty();
 expect(wrapper.find('span')).not.toBeEmpty();
+```
+
+#### `toBeEmptyRender()`
+
+| render | mount | shallow |
+| -------|-------|-------- |
+| no     | yes   | yes     |
+
+Assert that the given wrapper has an empty render (`null` or `false`):
+
+```js
+function EmptyRenderFixture() {
+  return null;
+}
+
+function NonEmptyRenderFixture() {
+  return (
+    <div>
+      <EmptyRenderFixture />
+    </div>
+  );
+}
+
+const wrapper = mount(<EmptyRenderFixture />); // mount/render/shallow when applicable
+
+expect(wrapper.find('EmptyRenderFixture')).toBeEmptyRender();
+expect(wrapper).not.toBeEmptyRender();
 ```
 
 #### `toBePresent()`

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toBeEmptyRender--tests.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toBeEmptyRender--tests.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`toBeEmptyRender provides contextual information for the message 1`] = `
+Object {
+  "actual": "Found Nodes HTML output: <div></div>",
+}
+`;
+
+exports[`toBeEmptyRender returns the message with the proper pass verbage 1`] = `"Expected <EmptyRenderFixture> to be empty render (false or null), but it was not"`;
+
+exports[`toBeEmptyRender returns the message with the proper pass verbage 2`] = `"Expected <EmptyRenderFixture> not to be empty render (false or null), but it was"`;

--- a/packages/enzyme-matchers/src/assertions/__tests__/toBeEmptyRender--tests.js
+++ b/packages/enzyme-matchers/src/assertions/__tests__/toBeEmptyRender--tests.js
@@ -1,0 +1,48 @@
+const { shallow, mount } = require('enzyme');
+const React = require('react');
+
+const toBeEmptyRender = require('../toBeEmptyRender');
+
+function EmptyRenderFixture() {
+  return null;
+}
+
+function NonEmptyRenderFixture() {
+  return (
+    <div>
+      <EmptyRenderFixture />
+    </div>
+  );
+}
+
+describe('toBeEmptyRender', () => {
+  const wrapper = mount(<NonEmptyRenderFixture />);
+
+  const truthyResults = toBeEmptyRender(wrapper.find('EmptyRenderFixture'));
+
+  const falsyResults = toBeEmptyRender(wrapper);
+
+  it('returns the pass flag properly', () => {
+    expect(truthyResults.pass).toBeTruthy();
+    expect(falsyResults.pass).toBeFalsy();
+  });
+
+  it('returns the message with the proper pass verbage', () => {
+    expect(truthyResults.message).toMatchSnapshot();
+    expect(truthyResults.negatedMessage).toMatchSnapshot();
+  });
+
+  it('provides contextual information for the message', () => {
+    expect(falsyResults.contextualInformation).toMatchSnapshot();
+  });
+
+  it('considers both false and null to be empty renders', () => {
+    const NullRenderer = () => null;
+    const nullWrapper = shallow(<NullRenderer />);
+    expect(toBeEmptyRender(nullWrapper)).toBeTruthy();
+
+    const FalseRenderer = () => false;
+    const falseWrapper = shallow(<FalseRenderer />);
+    expect(toBeEmptyRender(falseWrapper)).toBeTruthy();
+  });
+});

--- a/packages/enzyme-matchers/src/assertions/toBeEmptyRender.js
+++ b/packages/enzyme-matchers/src/assertions/toBeEmptyRender.js
@@ -1,0 +1,28 @@
+/**
+ * This source code is licensed under the MIT-style license found in the
+ * LICENSE file in the root directory of this source tree. *
+ *
+ * @providesModule toBeEmptyRenderAssertion
+ * @flow
+ */
+
+import type { EnzymeObject, Matcher } from '../types';
+import name from '../utils/name';
+import html from '../utils/html';
+
+export default function toBeEmptyRender(enzymeWrapper: EnzymeObject): Matcher {
+  const pass = enzymeWrapper.isEmptyRender();
+
+  return {
+    pass,
+    message: `Expected <${name(
+      enzymeWrapper
+    )}> to be empty render (false or null), but it was not`,
+    negatedMessage: `Expected <${name(
+      enzymeWrapper
+    )}> not to be empty render (false or null), but it was`,
+    contextualInformation: {
+      actual: `Found Nodes HTML output: ${html(enzymeWrapper)}`,
+    },
+  };
+}

--- a/packages/enzyme-matchers/src/index.js
+++ b/packages/enzyme-matchers/src/index.js
@@ -9,6 +9,7 @@
 import toBeChecked from './assertions/toBeChecked';
 import toBeDisabled from './assertions/toBeDisabled';
 import toBeEmpty from './assertions/toBeEmpty';
+import toBeEmptyRender from './assertions/toBeEmptyRender';
 import toBePresent from './assertions/toBePresent';
 import toContainReact from './assertions/toContainReact';
 import toHaveClassName from './assertions/toHaveClassName';
@@ -30,6 +31,7 @@ const assertions = {
   toBeChecked,
   toBeDisabled,
   toBeEmpty,
+  toBeEmptyRender,
   toBePresent,
   toContainReact,
   toHaveClassName,

--- a/packages/jasmine-enzyme/spec/ensure-matchers-are-added--spec.js
+++ b/packages/jasmine-enzyme/spec/ensure-matchers-are-added--spec.js
@@ -40,6 +40,13 @@ describe('addMatchers', () => {
     expect(wrapper.find('.doesnt-match')).toBeEmpty();
   });
 
+  it('adds toBeEmptyRender', () => {
+    const Fixture = require('./fixtures/toBeEmptyRender.fixture');
+    const wrapper = shallow(React.createElement(Fixture));
+
+    expect(wrapper).toBeEmptyRender();
+  });
+
   it('adds toBePresent', () => {
     const Fixture = require('./fixtures/toBePresent.fixture');
     const wrapper = shallow(React.createElement(Fixture));

--- a/packages/jasmine-enzyme/spec/fixtures/toBeEmptyRender.fixture.js
+++ b/packages/jasmine-enzyme/spec/fixtures/toBeEmptyRender.fixture.js
@@ -1,0 +1,12 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true,
+});
+exports.default = Fixture;
+var React = require('react');
+
+function Fixture() {
+  return null;
+}
+module.exports = exports['default'];

--- a/packages/jest-enzyme/src/__failing_tests__/toBeEmptyRender.test.js
+++ b/packages/jest-enzyme/src/__failing_tests__/toBeEmptyRender.test.js
@@ -1,0 +1,25 @@
+const { shallow, mount } = require('enzyme');
+const React = require('react');
+
+describe('failing test', () => {
+  [shallow, mount].forEach(builder => {
+    describe(builder.name, () => {
+      const EmptyRenderFixture = () => null;
+
+      const NonEmptyRenderFixture = () =>
+        <div>
+          <EmptyRenderFixture />
+        </div>;
+
+      it('fails toBeEmptyRender', () => {
+        expect(builder(<NonEmptyRenderFixture />)).toBeEmptyRender();
+      });
+
+      it('fails NOT toBeEmptyRender', () => {
+        expect(
+          builder(<EmptyRenderFixture />).find('EmptyRenderFixture')
+        ).not.toBeEmptyRender();
+      });
+    });
+  });
+});

--- a/packages/jest-enzyme/src/index.d.ts
+++ b/packages/jest-enzyme/src/index.d.ts
@@ -5,6 +5,7 @@ declare namespace jest {
         toBeChecked(): void;
         toBeDisabled(): void;
         toBeEmpty(): void;
+        toBeEmptyRender(): void;
         toBePresent(): void;
         toContainReact(component: React.ReactElement<any>): void;
         toHaveClassName(className: string): void;


### PR DESCRIPTION
Wraps Enzyme's `isEmptyRender()` which verifies that a component returned a valid falsy value (`false` or `null`).