### PR TITLE
remove unnecessary raf polyfill

### DIFF
--- a/packages/jest-environment-enzyme/src/setup.js
+++ b/packages/jest-environment-enzyme/src/setup.js
@@ -1,39 +1,4 @@
-/* globals window */
-/* eslint-disable global-require, no-plusplus */
-// http://paulirish.com/2011/requestanimationframe-for-smart-animating/
-// http://my.opera.com/emoller/blog/2011/12/20/requestanimationframe-for-smart-er-animating
-// requestAnimationFrame polyfill by Erik Möller. fixes from Paul Irish and Tino Zijdel
-// MIT license
-export const polyfillRaf = () => {
-  if (typeof window === 'undefined') return;
-
-  let lastTime = 0;
-  const vendors = ['ms', 'moz', 'webkit', 'o'];
-  for (let x = 0; x < vendors.length && !window.requestAnimationFrame; ++x) {
-    window.requestAnimationFrame = window[`${vendors[x]}RequestAnimationFrame`];
-    window.cancelAnimationFrame =
-      window[`${vendors[x]}CancelAnimationFrame`] ||
-      window[`${vendors[x]}CancelRequestAnimationFrame`];
-  }
-
-  if (!window.requestAnimationFrame) {
-    window.requestAnimationFrame = function requestAnimationFrame(callback) {
-      const currTime = new Date().getTime();
-      const timeToCall = Math.max(0, 16 - (currTime - lastTime));
-      const id = window.setTimeout(() => {
-        callback(currTime + timeToCall);
-      }, timeToCall);
-      lastTime = currTime + timeToCall;
-      return id;
-    };
-  }
-
-  if (!window.cancelAnimationFrame) {
-    window.cancelAnimationFrame = function cancelAnimationFrame(id) {
-      clearTimeout(id);
-    };
-  }
-};
+/* eslint-disable global-require */
 
 export const exposeGlobals = () => {
   let Adapter;

--- a/packages/jest-enzyme/src/index.js
+++ b/packages/jest-enzyme/src/index.js
@@ -13,12 +13,8 @@ import serializer from 'enzyme-to-json/serializer';
 declare var expect: Function;
 
 if (global.bootstrapEnzymeEnvironment) {
-  const {
-    exposeGlobals,
-    polyfillRaf,
-  } = require('jest-environment-enzyme/lib/setup');
+  const { exposeGlobals } = require('jest-environment-enzyme/lib/setup');
 
-  polyfillRaf();
   exposeGlobals();
 }
 


### PR DESCRIPTION
Since the environment extends jest-environment@22 (https://github.com/FormidableLabs/enzyme-matchers/blob/466d2df25d0887ab573ef190631b47b4202a8ce4/packages/jest-environment-enzyme/package.json#L52) it means that jsdom@11.5 is pulled in (https://github.com/facebook/jest/blob/v22.4.2/packages/jest-environment-jsdom/package.json#L13), which includes `requestAnimationFrame` out of the box (since jsdom 11.4.0: https://github.com/jsdom/jsdom/blob/dc672a2544bd269cfbf311ae7ab0d06aa4d8d170/Changelog.md#1140)

Whew 😅