### PR TITLE
Allow propKey to be an Object

### DIFF
--- a/packages/enzyme-matchers/src/assertions/toHaveProp.js
+++ b/packages/enzyme-matchers/src/assertions/toHaveProp.js
@@ -14,7 +14,7 @@ import single from '../utils/single';
 
 function toHaveProp(
   enzymeWrapper: EnzymeObject,
-  propKey: string,
+  propKey: string | Object,
   propValue?: any
 ): Matcher {
   const props = enzymeWrapper.props();


### PR DESCRIPTION
This matches the changes made for 5.0.0 in `toHaveStyle` and `toHaveState`.