### PR TITLE
Better linting file support

### DIFF
--- a/packages/eslint-config-jest-enzyme/index.js
+++ b/packages/eslint-config-jest-enzyme/index.js
@@ -1,7 +1,20 @@
 module.exports = {
   overrides: [
     {
-      files: ['**/*.test.js', '**/*.test.jsx'],
+      files: [
+        '**/*.test.js',
+        '**/*.test.jsx',
+        '**/*.test.ts',
+        '**/*.test.tsx',
+        '**/__tests__/**/*.test.js',
+        '**/__tests__/**/*.test.jsx',
+        '**/__tests__/**/*.test.ts',
+        '**/__tests__/**/*.test.tsx',
+        '**/__tests__/**/*.js',
+        '**/__tests__/**/*.jsx',
+        '**/__tests__/**/*.ts',
+        '**/__tests__/**/*.tsx',
+      ],
       globals: {
         React: true,
         mount: true,


### PR DESCRIPTION
The original file support was very weak and not sufficient for most applications.

This now supports ts, js, and jsx files within the following places:

```
**/*.test (colocated tests)
**/__tests__/**/*.test (nested test folder with test extension)
**/__tests__/**/* (nested test without test extension)
```