### PR TITLE
docs: Add setup file to env example configs

### DIFF
--- a/packages/jest-environment-enzyme/README.md
+++ b/packages/jest-environment-enzyme/README.md
@@ -32,6 +32,7 @@ Set the `testEnvironment` to `enzyme` in your `package.json`.
 
 ```js
 "jest": {
+  "setupTestFrameworkScriptFile": "jest-enzyme",
   "testEnvironment": "enzyme",
 },
 ```
@@ -49,6 +50,7 @@ Valid options are:
 ```js
 // package.json
 "jest": {
+  "setupTestFrameworkScriptFile": "jest-enzyme",
   "testEnvironment": "enzyme",
   "testEnvironmentOptions": {
     "enzymeAdapter": "react16"


### PR DESCRIPTION
Simply adding `"testEnvironment": "enzyme"` is _not_ sufficient, one must also add `"setupTestFrameworkScriptFile": "jest-enzyme"`. Otherwise, the whole kit & caboodle never loads, and sadness pervades one's existence.

This is likely related to #224, although I can't be sure...