### PR TITLE
fix: Use correct global when resolving enzymeAdapter

### DIFF
--- a/packages/jest-environment-enzyme/src/setup.js
+++ b/packages/jest-environment-enzyme/src/setup.js
@@ -1,8 +1,9 @@
 /* eslint-disable global-require */
 
+// eslint-disable-next-line import/prefer-default-export
 export const exposeGlobals = () => {
   let dep;
-  switch (global.enzymedepDescriptor) {
+  switch (global.enzymeAdapterDescriptor) {
     case 'react13':
       dep = 'enzyme-adapter-react-13';
       break;
@@ -22,8 +23,10 @@ export const exposeGlobals = () => {
 
   let Adapter;
   try {
+    // eslint-disable-next-line import/no-dynamic-require
     Adapter = require(dep);
   } catch (e) {
+    // eslint-disable-next-line no-console
     console.error(
       `
       Requiring the proper enzyme-adapter during jest-enzyme setup failed.


### PR DESCRIPTION
`jest-environment-enzyme`'s entry class [sets](https://github.com/FormidableLabs/enzyme-matchers/blob/eabc6acc50be85250ff63c860ad9fa72d1f4ac1d/packages/jest-environment-enzyme/src/index.js#L7) `global.enzymeAdapterDescriptor`, but setup.js was attempting to read `global.enzymedepDescriptor`, so it always defaulted to "react16". I only encountered this because I was attempting to implement `jest-environment-enzyme` in a (mono)repo that still depends on React 15 (upgrading enterprisey React is hard, lol).

I tested this by modifying the appropriate line in my local `node_modules` and verifying it passed. (Before the edit, I was getting a huge cascade of angry error logging claiming I didn't have the correct adapter, which was clearly not the case, as I had the enzyme 3 + react-15 adapter working manually prior to this)

There's a lot of ...odd lerna patterns in this monorepo, but I left those edits out in the interest of focused changes. If there is interest, I can open a PR with those changes (run build/test/lint from the root, no `scripts/jest.js`, etc).