### PR TITLE
Add type definitions for globals

### DIFF
--- a/packages/jest-enzyme/package.json
+++ b/packages/jest-enzyme/package.json
@@ -54,6 +54,7 @@
     "jest-environment-enzyme": "^6.0.2"
   },
   "devDependencies": {
+    "@types/enzyme": "^3.1.11",
     "@types/react": "^16.0.10"
   },
   "jest": {

--- a/packages/jest-enzyme/src/index.d.ts
+++ b/packages/jest-enzyme/src/index.d.ts
@@ -1,5 +1,13 @@
 /// <reference types="react" />
 
+import * as Enzyme from 'enzyme';
+
+declare global {
+    var shallow: typeof Enzyme.shallow;
+    var mount: typeof Enzyme.mount;
+    var render: typeof Enzyme.render;
+}
+
 declare namespace jest {
     interface Matchers<R> {
         toBeChecked(): void;


### PR DESCRIPTION
[This](https://github.com/FormidableLabs/enzyme-matchers/blob/master/packages/jest-environment-enzyme/src/setup.js#L49-L51) currently defines some globals so that, for example, `mount(...)` can be used without having to `import { mount } from 'enzyme';`.

The problem with this is that TypeScript is not able to find out where this comes from so I'm trying to define the aliasing from `enzyme` in there:

```ts
$ tsc
src/index.tsx:19:3 - error TS2304: Cannot find name 'mount'.

19   mount(
     ~~~~~
```

Note that **this does not seem to work** and I can't figure it out. ~It seems like these definitions do not get picked up.~ EDIT: I was just forgetting to manually import the types, but I'm still getting some version of this issue, see in my next comment.
Would someone be able to help identifying the issue?