### PR TITLE
Must not overwrite the error message without the reference of the original

### DIFF
--- a/packages/jest-environment-enzyme/src/setup.js
+++ b/packages/jest-environment-enzyme/src/setup.js
@@ -38,7 +38,7 @@ export const exposeGlobals = () => {
       or with npm
       
       > npm i --save-dev ${dep}
-      `
+      `, e,
     );
     return;
   }


### PR DESCRIPTION
You must not overwrite the error message without the reference of the original.

In this case the require function fails, there is not only the case you know.

For example, when developing with react-native, "react-dom" may not be added to the dependency of the project. And "enzyme-adapter-react-XX" refers to "react-dom". However, the adapter module does not add this to its dependency.
In this case, "yarn add --dev $ {dep}" or "npm i --save - dev $ {dep}", you suggest as a solution, will not solve the problem.
And the original error you are discarding contains the message that "react-dom" can not be referenced. Then if a developer could see the original message, he/she can solve the problem easily.

So that you must not ignore the original error message.