### PR TITLE
Ignore whitespaces between tags by toHaveHTML

### DIFF
--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toHaveHTML.test.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toHaveHTML.test.js.snap
@@ -2,8 +2,8 @@
 
 exports[`toHaveHTML mount provides contextual information for the message (mount) 1`] = `
 Object {
-  "actual": "Actual HTML: <span id=\\"child\\">Test</span>",
-  "expected": "Expected HTML: <span id=\\"child\\">Test</span>",
+  "actual": "Actual HTML: <span id=\\"child\\"><b>Test</b></span>",
+  "expected": "Expected HTML: <span id=\\"child\\"><b>Test</b></span>",
 }
 `;
 
@@ -13,8 +13,8 @@ exports[`toHaveHTML mount returns the message with the proper pass verbage (moun
 
 exports[`toHaveHTML shallow provides contextual information for the message (shallow) 1`] = `
 Object {
-  "actual": "Actual HTML: <span id=\\"child\\">Test</span>",
-  "expected": "Expected HTML: <span id=\\"child\\">Test</span>",
+  "actual": "Actual HTML: <span id=\\"child\\"><b>Test</b></span>",
+  "expected": "Expected HTML: <span id=\\"child\\"><b>Test</b></span>",
 }
 `;
 

--- a/packages/enzyme-matchers/src/assertions/__tests__/toHaveHTML.test.js
+++ b/packages/enzyme-matchers/src/assertions/__tests__/toHaveHTML.test.js
@@ -3,22 +3,33 @@ const toHaveHTML = require('../toHaveHTML');
 function Fixture() {
   return (
     <div id="root">
-      <span id="child">Test</span>
+      <span id="child">
+        <b>Test</b>
+      </span>
     </div>
   );
 }
 
-const html = '<span id="child">Test</span>';
+const html = '<span id="child"><b>Test</b></span>';
+
+const multilineHtml = `<span id="child">
+    <b>Test</b>
+  </span>`;
 
 describe('toHaveHTML', () => {
   [shallow, mount].forEach(builder => {
     describe(builder.name, () => {
       const wrapper = builder(<Fixture />);
       const truthyResults = toHaveHTML(wrapper.find('#child'), html);
+      const truthyMultilineResults = toHaveHTML(
+        wrapper.find('#child'),
+        multilineHtml
+      );
       const falsyResults = toHaveHTML(wrapper.find('#child'), 'foo');
 
       it('returns the pass flag properly', () => {
         expect(truthyResults.pass).toBeTruthy();
+        expect(truthyMultilineResults.pass).toBeTruthy();
         expect(falsyResults.pass).toBeFalsy();
       });
 

--- a/packages/enzyme-matchers/src/assertions/toHaveHTML.js
+++ b/packages/enzyme-matchers/src/assertions/toHaveHTML.js
@@ -17,7 +17,9 @@ function toHaveHTML(enzymeWrapper: EnzymeObject, html: string): Matcher {
   const useSingleQuotes = html.search("'") !== -1;
 
   const actualHTML = wrapperHTML.replace(/("|')/g, useSingleQuotes ? "'" : '"');
-  const expectedHTML = html.replace(/("|')/g, useSingleQuotes ? "'" : '"');
+  const expectedHTML = html
+    .replace(/("|')/g, useSingleQuotes ? "'" : '"')
+    .replace(/>[\n\t ]+</g, '><');
 
   const pass = actualHTML === expectedHTML;
 


### PR DESCRIPTION
This makes passing multiline strings possible.

Resolves #246, see this issue for example of what this can do.