### PR TITLE
Replace misleading usage of `toHaveProp` in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,9 +301,9 @@ expect(wrapper.find('#child')).toHaveHTML(
 Ways to use this API:
 
 ```js
-expect().toHaveProp('key', 'value');
-expect().toHaveProp('key');
-expect().toHaveProp({key: 'value'});
+expect().toHaveProp('foo', 'value');
+expect().toHaveProp('foo');
+expect().toHaveProp({foo: 'value'});
 ```
 
 Assert that the given wrapper has the provided propKey and associated value if specified:


### PR DESCRIPTION
The example usage of `toHaveProp` in the README shows it being used to make assertions about a component's `key` prop. As far as I can tell, you actually can't make assertions about `key` using `toHaveProp` - React treats `key` specially and doesn't expose it as a regular prop. 

I got tripped up by this subtlety today, and was extra confused as to why it wasn't working since the example of `toHaveProp` in the readme was using `key`. Hopefully, this small change will save someone else a few mins down the road.

BTW, if there is interest I'd be happy to take a run at adding a `toHaveKey` matcher in a separate PR.