### PR TITLE
Move the globals type definitions to the separate typings file

### DIFF
--- a/packages/jest-environment-enzyme/package.json
+++ b/packages/jest-environment-enzyme/package.json
@@ -16,6 +16,7 @@
   "files": [
     "lib"
   ],
+  "types": "lib/index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/FormidableLabs/enzyme-matchers.git"

--- a/packages/jest-environment-enzyme/src/index.d.ts
+++ b/packages/jest-environment-enzyme/src/index.d.ts
@@ -1,0 +1,7 @@
+import * as Enzyme from 'enzyme';
+
+declare global {
+    var shallow: typeof Enzyme.shallow;
+    var mount: typeof Enzyme.mount;
+    var render: typeof Enzyme.render;
+}

--- a/packages/jest-enzyme/src/index.d.ts
+++ b/packages/jest-enzyme/src/index.d.ts
@@ -1,13 +1,5 @@
 /// <reference types="react" />
 
-import * as Enzyme from 'enzyme';
-
-declare global {
-    var shallow: typeof Enzyme.shallow;
-    var mount: typeof Enzyme.mount;
-    var render: typeof Enzyme.render;
-}
-
 declare namespace jest {
     interface Matchers<R> {
         toBeChecked(): void;


### PR DESCRIPTION
Move the globals type definitions from packages\jest-enzyme\src\index.d.ts to packages\jest-environment-enzyme\src\index.d.ts.
Fixes #252.