### PR TITLE
Adding matchers for assertions based on enzyme selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ This library supports several testing frameworks including [Jest](https://github
 * [toBeDisabled()](#tobedisabled)
 * [toBeEmptyRender()](#tobeemptyrender)
 * [toExist()](#toexist)
+* [toContainMatchingElement()](#toContainMatchingElement)
+* [toContainMatchingElements()](#toContainMatchingElements)
+* [toContainExactlyOneMatchingElement()](#toContainExactlyOneMatchingElement)
 * [toContainReact()](#tocontainreact)
 * [toHaveClassName()](#tohaveclassname)
 * [toHaveHTML()](#tohavehtml)
@@ -178,6 +181,153 @@ const wrapper = mount(<Fixture />); // mount/render/shallow when applicable
 
 expect(wrapper.find('span')).toExist();
 expect(wrapper.find('ul')).not.toExist();
+```
+
+#### `toContainMatchingElement()`
+
+| render | mount | shallow |
+| -------|-------|-------- |
+| no     | yes   | yes     |
+
+Ways to use this API:
+
+```js
+expect().toContainMatchingElement('.foo');
+```
+
+Assert that the given wrapper contains at least one match for the given selector:
+
+```js
+function User(props) {
+  return (
+    <span className={props.className}>
+      User {props.index}
+    </span>
+  );
+}
+
+User.propTypes = {
+  index: PropTypes.number.isRequired,
+  className: PropTypes.string,
+};
+
+function Fixture() {
+  return (
+    <div>
+      <ul>
+        <li>
+          <User index={1} className="userOne" />
+        </li>
+        <li>
+          <User index={2} className="userTwo" />
+        </li>
+      </ul>
+    </div>
+  );
+}
+
+const wrapper = mount(<Fixture />); // mount/render/shallow when applicable
+
+expect(wrapper).toContainMatchingElement('.userOne');
+expect(wrapper).not.toContainMatchingElement('.userThree');
+```
+
+#### `toContainMatchingElements()`
+
+| render | mount | shallow |
+| -------|-------|-------- |
+| no     | yes   | yes     |
+
+Ways to use this API:
+
+```js
+expect().toContainMatchingElements(2, '.foo');
+```
+
+Assert that the given wrapper contains a given number of matches for the given selector:
+
+```js
+function User(props) {
+  return (
+    <span className={props.className}>
+      User {props.index}
+    </span>
+  );
+}
+
+User.propTypes = {
+  index: PropTypes.number.isRequired,
+  className: PropTypes.string,
+};
+
+function Fixture() {
+  return (
+    <div>
+      <ul>
+        <li>
+          <User index={1} className="userOne" />
+        </li>
+        <li>
+          <User index={2} className="userTwo" />
+        </li>
+      </ul>
+    </div>
+  );
+}
+
+const wrapper = mount(<Fixture />); // mount/render/shallow when applicable
+
+expect(wrapper).toContainMatchingElements(2, 'User');
+expect(wrapper).not.toContainMatchingElements(2, '.userTwo');
+```
+
+#### `toContainExactlyOneMatchingElement()`
+
+| render | mount | shallow |
+| -------|-------|-------- |
+| no     | yes   | yes     |
+
+Ways to use this API:
+
+```js
+expect().toContainExactlyOneMatchingElement('.foo');
+```
+
+Assert that the given wrapper contains exactly one match for the given selector:
+
+```js
+function User(props) {
+  return (
+    <span className={props.className}>
+      User {props.index}
+    </span>
+  );
+}
+
+User.propTypes = {
+  index: PropTypes.number.isRequired,
+  className: PropTypes.string,
+};
+
+function Fixture() {
+  return (
+    <div>
+      <ul>
+        <li>
+          <User index={1} className="userOne" />
+        </li>
+        <li>
+          <User index={2} className="userTwo" />
+        </li>
+      </ul>
+    </div>
+  );
+}
+
+const wrapper = mount(<Fixture />); // mount/render/shallow when applicable
+
+expect(wrapper).toContainExactlyOneMatchingElement('.userOne');
+expect(wrapper).not.toContainExactlyOneMatchingElement('User');
 ```
 
 #### `toContainReact()`

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainExactlyOneMatchingElement.test.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainExactlyOneMatchingElement.test.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`toContainExactlyOneMatchingElement provides contextual information for the message 1`] = `
+Object {
+  "actual": "HTML Output of <div>:
+ <div><ul><li><User index={1} className=\\"userOne\\" /></li><li><User index={2} className=\\"userTwo\\" /></li></ul></div>",
+}
+`;
+
+exports[`toContainExactlyOneMatchingElement provides contextual information for the message 2`] = `
+Object {
+  "actual": "HTML Output of <div>:
+ <div><ul><li><User index={1} className=\\"userOne\\" /></li><li><User index={2} className=\\"userTwo\\" /></li></ul></div>",
+}
+`;
+
+exports[`toContainExactlyOneMatchingElement returns the message with the proper fail verbage 1`] = `"Expected <div> to not contain 1 element matching User but it did."`;
+
+exports[`toContainExactlyOneMatchingElement returns the message with the proper fail verbage 2`] = `"Expected <div> to not contain 1 element matching .userThree but it did."`;
+
+exports[`toContainExactlyOneMatchingElement returns the message with the proper fail verbage 3`] = `"Expected <div> to not contain 1 element matching [index] but it did."`;
+
+exports[`toContainExactlyOneMatchingElement returns the message with the proper pass verbage 1`] = `"Expected <div> to contain 1 element matching .userOne but 1 was found."`;
+
+exports[`toContainExactlyOneMatchingElement returns the message with the proper pass verbage 2`] = `"Expected <div> to contain 1 element matching [index=1] but 1 was found."`;

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainMatchingElement.test.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainMatchingElement.test.js.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`toContainMatchingElement provides contextual information for the message 1`] = `
+Object {
+  "actual": "HTML Output of <div>:
+ <div><ul><li><User index={1} className=\\"userOne\\" /></li><li><User index={2} className=\\"userTwo\\" /></li></ul></div>",
+}
+`;
+
+exports[`toContainMatchingElement provides contextual information for the message 2`] = `
+Object {
+  "actual": "HTML Output of <div>:
+ <div><ul><li><User index={1} className=\\"userOne\\" /></li><li><User index={2} className=\\"userTwo\\" /></li></ul></div>",
+}
+`;
+
+exports[`toContainMatchingElement provides contextual information for the message 3`] = `
+Object {
+  "actual": "HTML Output of <div>:
+ <div><ul><li><User index={1} className=\\"userOne\\" /></li><li><User index={2} className=\\"userTwo\\" /></li></ul></div>",
+}
+`;
+
+exports[`toContainMatchingElement returns the message with the proper fail verbage 1`] = `"Expected <div> to not contain an element matching Foo but it did."`;
+
+exports[`toContainMatchingElement returns the message with the proper fail verbage 2`] = `"Expected <div> to not contain an element matching .userThree but it did."`;
+
+exports[`toContainMatchingElement returns the message with the proper pass verbage 1`] = `"Expected <div> to contain at least one element matching User but none were found."`;
+
+exports[`toContainMatchingElement returns the message with the proper pass verbage 2`] = `"Expected <div> to contain at least one element matching [index=1] but none were found."`;
+
+exports[`toContainMatchingElement returns the message with the proper pass verbage 3`] = `"Expected <div> to contain at least one element matching [index] but none were found."`;

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainMatchingElements.test.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainMatchingElements.test.js.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`toContainMatchingElements provides contextual information for the message 1`] = `
+Object {
+  "actual": "HTML Output of <div>:
+ <div><ul><li><User index={1} className=\\"userOne\\" /></li><li><User index={2} className=\\"userTwo\\" /></li></ul></div>",
+}
+`;
+
+exports[`toContainMatchingElements provides contextual information for the message 2`] = `
+Object {
+  "actual": "HTML Output of <div>:
+ <div><ul><li><User index={1} className=\\"userOne\\" /></li><li><User index={2} className=\\"userTwo\\" /></li></ul></div>",
+}
+`;
+
+exports[`toContainMatchingElements provides contextual information for the message 3`] = `
+Object {
+  "actual": "HTML Output of <div>:
+ <div><ul><li><User index={1} className=\\"userOne\\" /></li><li><User index={2} className=\\"userTwo\\" /></li></ul></div>",
+}
+`;
+
+exports[`toContainMatchingElements returns the message with the proper fail verbage 1`] = `"Expected <div> to not contain 3 elements matching User but it did."`;
+
+exports[`toContainMatchingElements returns the message with the proper fail verbage 2`] = `"Expected <div> to not contain 1 element matching .userThree but it did."`;
+
+exports[`toContainMatchingElements returns the message with the proper fail verbage 3`] = `"Expected <div> to not contain 1 element matching [index] but it did."`;
+
+exports[`toContainMatchingElements returns the message with the proper pass verbage 1`] = `"Expected <div> to contain 2 elements matching User but 2 were found."`;
+
+exports[`toContainMatchingElements returns the message with the proper pass verbage 2`] = `"Expected <div> to contain 1 element matching [index=1] but 1 was found."`;
+
+exports[`toContainMatchingElements returns the message with the proper pass verbage 3`] = `"Expected <div> to contain 2 elements matching [index] but 2 were found."`;

--- a/packages/enzyme-matchers/src/assertions/__tests__/toContainExactlyOneMatchingElement.test.js
+++ b/packages/enzyme-matchers/src/assertions/__tests__/toContainExactlyOneMatchingElement.test.js
@@ -1,0 +1,70 @@
+const PropTypes = require('prop-types');
+
+const toContainExactlyOneMatchingElement = require('../toContainExactlyOneMatchingElement');
+
+function User(props) {
+  return (
+    <span>
+      User {props.index}
+    </span>
+  );
+}
+
+User.propTypes = {
+  index: PropTypes.number.isRequired,
+};
+
+function Fixture() {
+  return (
+    <div>
+      <ul>
+        <li>
+          <User index={1} className="userOne" />
+        </li>
+        <li>
+          <User index={2} className="userTwo" />
+        </li>
+      </ul>
+    </div>
+  );
+}
+
+describe('toContainExactlyOneMatchingElement', () => {
+  const wrapper = shallow(<Fixture />);
+  const truthyResults = [
+    toContainExactlyOneMatchingElement(wrapper, '.userOne'),
+    toContainExactlyOneMatchingElement(wrapper, '[index=1]'),
+  ];
+  const falsyResults = [
+    toContainExactlyOneMatchingElement(wrapper, 'User'),
+    toContainExactlyOneMatchingElement(wrapper, '.userThree'),
+    toContainExactlyOneMatchingElement(wrapper, '[index]'),
+  ];
+
+  it('returns the pass flag properly', () => {
+    truthyResults.forEach(truthyResult => {
+      expect(truthyResult.pass).toBeTruthy();
+    });
+    falsyResults.forEach(falsyResult => {
+      expect(falsyResult.pass).toBeFalsy();
+    });
+  });
+
+  it('returns the message with the proper pass verbage', () => {
+    truthyResults.forEach(truthyResult => {
+      expect(truthyResult.message).toMatchSnapshot();
+    });
+  });
+
+  it('returns the message with the proper fail verbage', () => {
+    falsyResults.forEach(falsyResult => {
+      expect(falsyResult.negatedMessage).toMatchSnapshot();
+    });
+  });
+
+  it('provides contextual information for the message', () => {
+    truthyResults.forEach(truthyResult => {
+      expect(truthyResult.contextualInformation).toMatchSnapshot();
+    });
+  });
+});

--- a/packages/enzyme-matchers/src/assertions/__tests__/toContainMatchingElement.test.js
+++ b/packages/enzyme-matchers/src/assertions/__tests__/toContainMatchingElement.test.js
@@ -1,0 +1,71 @@
+const PropTypes = require('prop-types');
+
+const toContainMatchingElement = require('../toContainMatchingElement');
+
+function User(props) {
+  return (
+    <span className={props.className}>
+      User {props.index}
+    </span>
+  );
+}
+
+User.propTypes = {
+  index: PropTypes.number.isRequired,
+  className: PropTypes.string,
+};
+
+function Fixture() {
+  return (
+    <div>
+      <ul>
+        <li>
+          <User index={1} className="userOne" />
+        </li>
+        <li>
+          <User index={2} className="userTwo" />
+        </li>
+      </ul>
+    </div>
+  );
+}
+
+describe('toContainMatchingElement', () => {
+  const wrapper = shallow(<Fixture />);
+  const truthyResults = [
+    toContainMatchingElement(wrapper, 'User'),
+    toContainMatchingElement(wrapper, '[index=1]'),
+    toContainMatchingElement(wrapper, '[index]'),
+  ];
+  const falsyResults = [
+    toContainMatchingElement(wrapper, 'Foo'),
+    toContainMatchingElement(wrapper, '.userThree'),
+  ];
+
+  it('returns the pass flag properly', () => {
+    truthyResults.forEach(truthyResult => {
+      expect(truthyResult.pass).toBeTruthy();
+    });
+    falsyResults.forEach(falsyResult => {
+      expect(falsyResult.pass).toBeFalsy();
+    });
+  });
+
+  it('returns the message with the proper pass verbage', () => {
+    truthyResults.forEach(truthyResult => {
+      expect(truthyResult.message).toMatchSnapshot();
+    });
+  });
+
+  it('returns the message with the proper fail verbage', () => {
+    falsyResults.forEach(falsyResult => {
+      expect(falsyResult.negatedMessage).toMatchSnapshot();
+    });
+  });
+
+  it('provides contextual information for the message', () => {
+    truthyResults.forEach(truthyResult => {
+      expect(truthyResult.contextualInformation).toMatchSnapshot();
+    });
+  });
+});

--- a/packages/enzyme-matchers/src/assertions/__tests__/toContainMatchingElements.test.js
+++ b/packages/enzyme-matchers/src/assertions/__tests__/toContainMatchingElements.test.js
@@ -1,0 +1,72 @@
+const PropTypes = require('prop-types');
+
+const toContainMatchingElements = require('../toContainMatchingElements');
+
+function User(props) {
+  return (
+    <span className={props.className}>
+      User {props.index}
+    </span>
+  );
+}
+
+User.propTypes = {
+  index: PropTypes.number.isRequired,
+  className: PropTypes.string,
+};
+
+function Fixture() {
+  return (
+    <div>
+      <ul>
+        <li>
+          <User index={1} className="userOne" />
+        </li>
+        <li>
+          <User index={2} className="userTwo" />
+        </li>
+      </ul>
+    </div>
+  );
+}
+
+describe('toContainMatchingElements', () => {
+  const wrapper = shallow(<Fixture />);
+  const truthyResults = [
+    toContainMatchingElements(wrapper, 2, 'User'),
+    toContainMatchingElements(wrapper, 1, '[index=1]'),
+    toContainMatchingElements(wrapper, 2, '[index]'),
+  ];
+  const falsyResults = [
+    toContainMatchingElements(wrapper, 3, 'User'),
+    toContainMatchingElements(wrapper, 1, '.userThree'),
+    toContainMatchingElements(wrapper, 1, '[index]'),
+  ];
+
+  it('returns the pass flag properly', () => {
+    truthyResults.forEach(truthyResult => {
+      expect(truthyResult.pass).toBeTruthy();
+    });
+    falsyResults.forEach(falsyResult => {
+      expect(falsyResult.pass).toBeFalsy();
+    });
+  });
+
+  it('returns the message with the proper pass verbage', () => {
+    truthyResults.forEach(truthyResult => {
+      expect(truthyResult.message).toMatchSnapshot();
+    });
+  });
+
+  it('returns the message with the proper fail verbage', () => {
+    falsyResults.forEach(falsyResult => {
+      expect(falsyResult.negatedMessage).toMatchSnapshot();
+    });
+  });
+
+  it('provides contextual information for the message', () => {
+    truthyResults.forEach(truthyResult => {
+      expect(truthyResult.contextualInformation).toMatchSnapshot();
+    });
+  });
+});

--- a/packages/enzyme-matchers/src/assertions/toContainExactlyOneMatchingElement.js
+++ b/packages/enzyme-matchers/src/assertions/toContainExactlyOneMatchingElement.js
@@ -1,0 +1,19 @@
+/**
+ * This source code is licensed under the MIT-style license found in the
+ * LICENSE file in the root directory of this source tree. *
+ *
+ * @providesModule toContainExactlyOneMatchingElement
+ * @flow
+ */
+
+import type { EnzymeObject, Matcher } from '../types';
+import toContainMatchingElements from './toContainMatchingElements';
+
+function toContainExactlyOneMatchingElement(
+  enzymeWrapper: EnzymeObject,
+  selector: string
+): Matcher {
+  return toContainMatchingElements(enzymeWrapper, 1, selector);
+}
+
+export default toContainExactlyOneMatchingElement;

--- a/packages/enzyme-matchers/src/assertions/toContainMatchingElement.js
+++ b/packages/enzyme-matchers/src/assertions/toContainMatchingElement.js
@@ -1,0 +1,36 @@
+/**
+ * This source code is licensed under the MIT-style license found in the
+ * LICENSE file in the root directory of this source tree. *
+ *
+ * @providesModule toContainMatchingElement
+ * @flow
+ */
+
+import type { EnzymeObject, Matcher } from '../types';
+import html from '../utils/html';
+import getNodeName from '../utils/name';
+import single from '../utils/single';
+
+function toContainMatchingElement(
+  enzymeWrapper: EnzymeObject,
+  selector: string
+): Matcher {
+  const matches = enzymeWrapper.find(selector);
+  const pass = matches.length;
+  const nodeName = getNodeName(enzymeWrapper);
+
+  return {
+    pass,
+    message:
+      `Expected <${nodeName}> to contain at least one element matching ` +
+      `${selector} but none were found.`,
+    negatedMessage:
+      `Expected <${nodeName}> to not contain an element matching ` +
+      `${selector} but it did.`,
+    contextualInformation: {
+      actual: `HTML Output of <${nodeName}>:\n ${html(enzymeWrapper)}`,
+    },
+  };
+}
+
+export default single(toContainMatchingElement);

--- a/packages/enzyme-matchers/src/assertions/toContainMatchingElements.js
+++ b/packages/enzyme-matchers/src/assertions/toContainMatchingElements.js
@@ -1,0 +1,39 @@
+/**
+ * This source code is licensed under the MIT-style license found in the
+ * LICENSE file in the root directory of this source tree. *
+ *
+ * @providesModule toContainMatchingElements
+ * @flow
+ */
+
+import type { EnzymeObject, Matcher } from '../types';
+import html from '../utils/html';
+import getNodeName from '../utils/name';
+import single from '../utils/single';
+
+function toContainMatchingElements(
+  enzymeWrapper: EnzymeObject,
+  n: number,
+  selector: string
+): Matcher {
+  const matches = enzymeWrapper.find(selector);
+  const pass = matches.length === n;
+  const nodeName = getNodeName(enzymeWrapper);
+
+  return {
+    pass,
+    message:
+      `Expected <${nodeName}> to contain ${n} element${n === 1
+        ? ''
+        : 's'} matching ` +
+      `${selector} but ${matches.length} ${n === 1 ? 'was' : 'were'} found.`,
+    negatedMessage: `Expected <${nodeName}> to not contain ${n} element${n === 1
+      ? ''
+      : 's'} matching ${selector} but it did.`,
+    contextualInformation: {
+      actual: `HTML Output of <${nodeName}>:\n ${html(enzymeWrapper)}`,
+    },
+  };
+}
+
+export default single(toContainMatchingElements);

--- a/packages/enzyme-matchers/src/index.js
+++ b/packages/enzyme-matchers/src/index.js
@@ -9,6 +9,9 @@
 import toBeChecked from './assertions/toBeChecked';
 import toBeDisabled from './assertions/toBeDisabled';
 import toBeEmptyRender from './assertions/toBeEmptyRender';
+import toContainMatchingElement from './assertions/toContainMatchingElement';
+import toContainMatchingElements from './assertions/toContainMatchingElements';
+import toContainExactlyOneMatchingElement from './assertions/toContainExactlyOneMatchingElement';
 import toContainReact from './assertions/toContainReact';
 import toExist from './assertions/toExist';
 import toHaveClassName from './assertions/toHaveClassName';
@@ -30,6 +33,9 @@ const assertions = {
   toBeChecked,
   toBeDisabled,
   toBeEmptyRender,
+  toContainMatchingElement,
+  toContainMatchingElements,
+  toContainExactlyOneMatchingElement,
   toContainReact,
   toExist,
   toHaveClassName,

--- a/packages/jest-enzyme/src/index.d.ts
+++ b/packages/jest-enzyme/src/index.d.ts
@@ -5,7 +5,11 @@ declare namespace jest {
         toBeChecked(): void;
         toBeDisabled(): void;
         toBeEmptyRender(): void;
+        toContainMatchingElement(selector: string): void;
+        toContainMatchingElements(n: number, selector: string): void;
+        toContainMatchingElement(selector: string): void;
         toContainReact(component: React.ReactElement<any>): void;
+        toContainExactlyOneMatchingElement(selector: string): void;
         toExist(): void;
         toHaveClassName(className: string): void;
         toHaveHTML(html: string): void;


### PR DESCRIPTION
Adding three new matchers.

### toContainMatch('.foo')

Asserts that the given wrapper contains at least one match for the given selector.

### toContainMatches(2, '.foo')

Asserts that the given wrapper contains a given number of matches for the given selector.

### toContainExactlyOneMatch('.foo')

Asserts that the given wrapper contains exactly one match for the given selector.

Resolves #260