### PR TITLE
Support unboxed properties for `toMatchElement`

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,6 +724,7 @@ Ways to use this API:
 ```js
 expect().toMatchElement(<Foo />);
 expect().toMatchElement(<Foo />, { ignoreProps: false });
+expect().toMatchElement(<Foo />, { ignoreProps: false, verbose: false });
 ```
 
 Assert the wrapper matches the provided react instance. This is a matcher form of Enzyme's wrapper.matchesElement(), which returns a bool with no indication of what caused a failed match. This matcher includes the actual and expected debug trees as contextual information when it fails. Like matchesElement(), props are ignored. If you want to compare prop values as well, pass `{ ignoreProps: false }` as options. Uses enzyme's [debug()](http://airbnb.io/enzyme/docs/api/ShallowWrapper/debug.html) under the hood and compares debug strings, which makes for a human readable diff when expects fail.

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-react": "^7.4.0",
-    "enzyme": "^3.3.0",
+    "enzyme": "^3.4.0",
     "flow-bin": "^0.49.1",
     "flow-copy-source": "^1.2.0",
     "husky": "^0.14.3",

--- a/packages/enzyme-matchers/package.json
+++ b/packages/enzyme-matchers/package.json
@@ -28,14 +28,14 @@
     "url": "https://github.com/FormidableLabs/enzyme-matchers/issues"
   },
   "peerDependencies": {
-    "enzyme": "3.x"
+    "enzyme": ">=3.4.0"
   },
   "dependencies": {
     "circular-json-es6": "^2.0.1",
     "deep-equal-ident": "^1.1.1"
   },
   "devDependencies": {
-    "enzyme": "^3.0.0",
+    "enzyme": "^3.4.0",
     "flow-bin": "^0.66.0"
   },
   "jest": {

--- a/packages/enzyme-matchers/src/assertions/__tests__/toMatchElement.test.js
+++ b/packages/enzyme-matchers/src/assertions/__tests__/toMatchElement.test.js
@@ -1,6 +1,6 @@
 const toMatchElement = require('../toMatchElement');
 
-function Fixture() {
+function Fixture({ props }) {
   return (
     <div>
       <span id="child" className="foo" />
@@ -51,6 +51,31 @@ describe('toMatchElement', () => {
           truthyResultsIncludeProps.contextualInformation
         ).toMatchSnapshot();
       });
+    });
+
+    it('Supports props that are of object shape', () => {
+      function ArrayFixture({ prop }) {
+        return (
+          <div>
+            <span data-json={prop} />
+          </div>
+        );
+      }
+
+      const wrapper = builder(<ArrayFixture prop={[1, 2, 3]} />);
+      const failedResults = toMatchElement(
+        wrapper.find('span'),
+        <span data-json={[1, 2]} />,
+        { ignoreProps: false }
+      );
+      const passResults = toMatchElement(
+        wrapper.find('span'),
+        <span data-json={[1, 2, 3]} />,
+        { ignoreProps: false }
+      );
+
+      expect(failedResults.pass).toBe(false);
+      expect(passResults.pass).toBe(true);
     });
   });
 });

--- a/packages/enzyme-matchers/src/assertions/toMatchElement.js
+++ b/packages/enzyme-matchers/src/assertions/toMatchElement.js
@@ -23,8 +23,8 @@ function toMatchElement(
     expectedWrapper = shallow(reactInstance);
   }
 
-  const actual = actualEnzymeWrapper.debug(options);
-  const expected = expectedWrapper.debug(options);
+  const actual = actualEnzymeWrapper.debug({ verbose: true, ...options });
+  const expected = expectedWrapper.debug({ verbose: true, ...options });
   const pass = actual === expected;
 
   return {

--- a/packages/enzyme-matchers/src/types/ToMatchElementOptions.js
+++ b/packages/enzyme-matchers/src/types/ToMatchElementOptions.js
@@ -8,4 +8,5 @@
 
 export type ToMatchElementOptions = {
   ignoreProps?: boolean,
+  verbose?: boolean,
 };

--- a/packages/jasmine-enzyme/package.json
+++ b/packages/jasmine-enzyme/package.json
@@ -44,7 +44,7 @@
     "enzyme"
   ],
   "peerDependencies": {
-    "enzyme": "3.x"
+    "enzyme": ">=3.4.0"
   },
   "dependencies": {
     "enzyme-matchers": "^6.1.0"

--- a/packages/jest-enzyme/package.json
+++ b/packages/jest-enzyme/package.json
@@ -45,7 +45,7 @@
     "url": "https://github.com/FormidableLabs/enzyme-matchers/issues"
   },
   "peerDependencies": {
-    "enzyme": "3.x",
+    "enzyme": ">=3.4.0",
     "jest": ">=22.0.0"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -837,6 +837,14 @@ array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
 
+array.prototype.flat@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.2.1.tgz#812db8f02cad24d3fab65dd67eabe3b8903494a4"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.10.0"
+    function-bind "^1.1.1"
+
 arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
@@ -2573,26 +2581,29 @@ enzyme-to-json@^3.3.0:
   dependencies:
     lodash "^4.17.4"
 
-enzyme@^3.0.0, enzyme@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.3.0.tgz#0971abd167f2d4bf3f5bd508229e1c4b6dc50479"
+enzyme@^3.4.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.6.0.tgz#d213f280a258f61e901bc663d4cc2d6fd9a9dec8"
   dependencies:
+    array.prototype.flat "^1.2.1"
     cheerio "^1.0.0-rc.2"
-    function.prototype.name "^1.0.3"
-    has "^1.0.1"
+    function.prototype.name "^1.1.0"
+    has "^1.0.3"
     is-boolean-object "^1.0.0"
-    is-callable "^1.1.3"
+    is-callable "^1.1.4"
     is-number-object "^1.0.3"
     is-string "^1.0.4"
     is-subset "^0.1.1"
-    lodash "^4.17.4"
-    object-inspect "^1.5.0"
+    lodash.escape "^4.0.1"
+    lodash.isequal "^4.5.0"
+    object-inspect "^1.6.0"
     object-is "^1.0.1"
     object.assign "^4.1.0"
     object.entries "^1.0.4"
     object.values "^1.0.4"
     raf "^3.4.0"
     rst-selector-parser "^2.2.3"
+    string.prototype.trim "^1.1.2"
 
 err-code@^1.0.0:
   version "1.1.2"
@@ -2603,6 +2614,16 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
   dependencies:
     is-arrayish "^0.2.1"
+
+es-abstract@^1.10.0, es-abstract@^1.5.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.12.0.tgz#9dbbdd27c6856f0001421ca18782d786bf8a6165"
+  dependencies:
+    es-to-primitive "^1.1.1"
+    function-bind "^1.1.1"
+    has "^1.0.1"
+    is-callable "^1.1.3"
+    is-regex "^1.0.4"
 
 es-abstract@^1.5.1, es-abstract@^1.6.1, es-abstract@^1.7.0:
   version "1.7.0"
@@ -3222,12 +3243,12 @@ function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
 
-function.prototype.name@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.0.3.tgz#0099ae5572e9dd6f03c97d023fd92bcc5e639eac"
+function.prototype.name@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.0.tgz#8bd763cc0af860a859cc5d49384d74b932cd2327"
   dependencies:
     define-properties "^1.1.2"
-    function-bind "^1.1.0"
+    function-bind "^1.1.1"
     is-callable "^1.1.3"
 
 functional-red-black-tree@^1.0.1:
@@ -3512,6 +3533,12 @@ has@^1.0.1:
   dependencies:
     function-bind "^1.0.2"
 
+has@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  dependencies:
+    function-bind "^1.1.1"
+
 hawk@~6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/hawk/-/hawk-6.0.2.tgz#af4d914eb065f9b5ce4d9d11c1cb2126eecc3038"
@@ -3773,6 +3800,10 @@ is-callable@^1.1.1, is-callable@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
 
+is-callable@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
+
 is-ci@^1.0.10:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.0.10.tgz#f739336b2632365061a9d48270cd56ae3369318e"
@@ -3939,7 +3970,7 @@ is-promise@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
 
-is-regex@^1.0.3:
+is-regex@^1.0.3, is-regex@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
   dependencies:
@@ -4735,6 +4766,10 @@ lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
 
+lodash.escape@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.escape/-/lodash.escape-4.0.1.tgz#c9044690c21e04294beaa517712fded1fa88de98"
+
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
@@ -4753,6 +4788,10 @@ lodash.isequal@^3.0:
   dependencies:
     lodash._baseisequal "^3.0.0"
     lodash._bindcallback "^3.0.0"
+
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
 
 lodash.istypedarray@^3.0.0:
   version "3.0.6"
@@ -5350,9 +5389,9 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-inspect@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.5.0.tgz#9d876c11e40f485c79215670281b767488f9bfe3"
+object-inspect@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.6.0.tgz#c70b6cbf72f274aab4c34c0c82f5167bf82cf15b"
 
 object-is@^1.0.1:
   version "1.0.1"
@@ -6711,6 +6750,14 @@ string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
+
+string.prototype.trim@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz#d04de2c89e137f4d7d206f086b5ed2fae6be8cea"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.5.0"
+    function-bind "^1.0.2"
 
 string_decoder@~1.0.3:
   version "1.0.3"


### PR DESCRIPTION
Fixes #186 

I'm thinking about doing a major for this just to be safe. I don't think there are any situations in which this will break. But it's kind of hard to know.

In some ways, changing the peerDep to min 3.4.0 is a "breaking" change.