### PR TITLE
Fix jest-environment-enzyme version

### DIFF
--- a/packages/jest-enzyme/package.json
+++ b/packages/jest-enzyme/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "enzyme-matchers": "^6.1.1",
     "enzyme-to-json": "^3.3.0",
-    "jest-environment-enzyme": "^6.1.1"
+    "jest-environment-enzyme": "^6.1.0"
   },
   "devDependencies": {
     "@types/enzyme": "^3.1.11",


### PR DESCRIPTION
jest-environment-enzyme [doesn't have](https://www.npmjs.com/package/jest-environment-enzyme) `v6.1.1`.

Edit: see https://github.com/FormidableLabs/enzyme-matchers/issues/269