### PR TITLE
Verify stability of shallow tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ expect(wrapper.find(User)).toHaveProp({
 
 | render | mount | shallow |
 | -------|-------|-------- |
-| no     | yes   | no      |
+| no     | yes   | yes     |
 
 Ways to use this API:
 

--- a/packages/enzyme-matchers/src/utils/__tests__/isShallowWrapper.test.js
+++ b/packages/enzyme-matchers/src/utils/__tests__/isShallowWrapper.test.js
@@ -1,0 +1,24 @@
+import { shallow, mount, render } from 'enzyme';
+import isShallowWrapper from '../isShallowWrapper';
+
+const Fixture = () => <div />;
+
+describe('isShallowWrapper', () => {
+  it('is true for shallow components', () => {
+    const wrapper = shallow(<Fixture />);
+
+    expect(isShallowWrapper(wrapper)).toBeTruthy();
+  });
+
+  it('is false for mounted components', () => {
+    const wrapper = mount(<Fixture />);
+
+    expect(isShallowWrapper(wrapper)).toBeFalsy();
+  });
+
+  it('is false for rendered components', () => {
+    const wrapper = render(<Fixture />);
+
+    expect(isShallowWrapper(wrapper)).toBeFalsy();
+  });
+});


### PR DESCRIPTION
Addresses #41
Turns out, `toHaveRef` actually works with shallow. And we already had tests to support it. So I updated the documentation, and added a test for the shallow wrapper check