### PR TITLE
Update toContainMatchingElement to return explicit booleans

### DIFF
--- a/packages/enzyme-matchers/src/assertions/__tests__/toBeChecked.test.js
+++ b/packages/enzyme-matchers/src/assertions/__tests__/toBeChecked.test.js
@@ -17,8 +17,8 @@ describe('toBeChecked', () => {
   const falsyResults = toBeChecked(wrapper.find('#not'));
 
   it('returns the pass flag properly', () => {
-    expect(truthyResults.pass).toBeTruthy();
-    expect(falsyResults.pass).toBeFalsy();
+    expect(truthyResults.pass).toBe(true);
+    expect(falsyResults.pass).toBe(false);
   });
 
   it('returns the message with the proper pass verbage', () => {
@@ -36,12 +36,12 @@ describe('toBeChecked', () => {
   it('`checked` should take precedence over `defaultChecked`', () => {
     const result = toBeChecked(wrapper.find('#precedence'));
 
-    expect(result.pass).toBeTruthy();
+    expect(result.pass).toBe(true);
   });
 
   it('should not fail on undefined values', () => {
     const result = toBeChecked(wrapper.find('#safe'));
 
-    expect(result.pass).toBeFalsy();
+    expect(result.pass).toBe(false);
   });
 });

--- a/packages/enzyme-matchers/src/assertions/__tests__/toBeDisabled.test.js
+++ b/packages/enzyme-matchers/src/assertions/__tests__/toBeDisabled.test.js
@@ -15,8 +15,8 @@ describe('toBeDisabled', () => {
   const falsyResults = toBeDisabled(wrapper.find('#not'));
 
   it('returns the pass flag properly', () => {
-    expect(truthyResults.pass).toBeTruthy();
-    expect(falsyResults.pass).toBeFalsy();
+    expect(truthyResults.pass).toBe(true);
+    expect(falsyResults.pass).toBe(false);
   });
 
   it('returns the message with the proper pass verbage', () => {

--- a/packages/enzyme-matchers/src/assertions/__tests__/toBeEmptyRender.test.js
+++ b/packages/enzyme-matchers/src/assertions/__tests__/toBeEmptyRender.test.js
@@ -20,8 +20,8 @@ describe('toBeEmptyRender', () => {
   const falsyResults = toBeEmptyRender(wrapper);
 
   it('returns the pass flag properly', () => {
-    expect(truthyResults.pass).toBeTruthy();
-    expect(falsyResults.pass).toBeFalsy();
+    expect(truthyResults.pass).toBe(true);
+    expect(falsyResults.pass).toBe(false);
   });
 
   it('returns the message with the proper pass verbage', () => {
@@ -36,10 +36,10 @@ describe('toBeEmptyRender', () => {
   it('considers both false and null to be empty renders', () => {
     const NullRenderer = () => null;
     const nullWrapper = shallow(<NullRenderer />);
-    expect(toBeEmptyRender(nullWrapper)).toBeTruthy();
+    expect(toBeEmptyRender(nullWrapper).pass).toBe(true);
 
     const FalseRenderer = () => false;
     const falseWrapper = shallow(<FalseRenderer />);
-    expect(toBeEmptyRender(falseWrapper)).toBeTruthy();
+    expect(toBeEmptyRender(falseWrapper).pass).toBe(true);
   });
 });

--- a/packages/enzyme-matchers/src/assertions/__tests__/toContainExactlyOneMatchingElement.test.js
+++ b/packages/enzyme-matchers/src/assertions/__tests__/toContainExactlyOneMatchingElement.test.js
@@ -43,10 +43,10 @@ describe('toContainExactlyOneMatchingElement', () => {
 
   it('returns the pass flag properly', () => {
     truthyResults.forEach(truthyResult => {
-      expect(truthyResult.pass).toBeTruthy();
+      expect(truthyResult.pass).toBe(true);
     });
     falsyResults.forEach(falsyResult => {
-      expect(falsyResult.pass).toBeFalsy();
+      expect(falsyResult.pass).toBe(false);
     });
   });
 

--- a/packages/enzyme-matchers/src/assertions/__tests__/toContainMatchingElement.test.js
+++ b/packages/enzyme-matchers/src/assertions/__tests__/toContainMatchingElement.test.js
@@ -44,10 +44,10 @@ describe('toContainMatchingElement', () => {
 
   it('returns the pass flag properly', () => {
     truthyResults.forEach(truthyResult => {
-      expect(truthyResult.pass).toBeTruthy();
+      expect(truthyResult.pass).toBe(true);
     });
     falsyResults.forEach(falsyResult => {
-      expect(falsyResult.pass).toBeFalsy();
+      expect(falsyResult.pass).toBe(false);
     });
   });
 

--- a/packages/enzyme-matchers/src/assertions/__tests__/toContainMatchingElements.test.js
+++ b/packages/enzyme-matchers/src/assertions/__tests__/toContainMatchingElements.test.js
@@ -45,10 +45,10 @@ describe('toContainMatchingElements', () => {
 
   it('returns the pass flag properly', () => {
     truthyResults.forEach(truthyResult => {
-      expect(truthyResult.pass).toBeTruthy();
+      expect(truthyResult.pass).toBe(true);
     });
     falsyResults.forEach(falsyResult => {
-      expect(falsyResult.pass).toBeFalsy();
+      expect(falsyResult.pass).toBe(false);
     });
   });
 

--- a/packages/enzyme-matchers/src/assertions/__tests__/toContainReact.test.js
+++ b/packages/enzyme-matchers/src/assertions/__tests__/toContainReact.test.js
@@ -35,8 +35,8 @@ describe('toContainReact', () => {
   const falsyResults = toContainReact(wrapper, <User index={3} />);
 
   it('returns the pass flag properly', () => {
-    expect(truthyResults.pass).toBeTruthy();
-    expect(falsyResults.pass).toBeFalsy();
+    expect(truthyResults.pass).toBe(true);
+    expect(falsyResults.pass).toBe(false);
   });
 
   it('returns the message with the proper pass verbage', () => {

--- a/packages/enzyme-matchers/src/assertions/__tests__/toExist.test.js
+++ b/packages/enzyme-matchers/src/assertions/__tests__/toExist.test.js
@@ -14,8 +14,8 @@ describe('toExist', () => {
   const falsyResults = toExist(wrapper.find('.doesnt-matches'));
 
   it('returns the pass flag properly', () => {
-    expect(truthyResults.pass).toBeTruthy();
-    expect(falsyResults.pass).toBeFalsy();
+    expect(truthyResults.pass).toBe(true);
+    expect(falsyResults.pass).toBe(false);
   });
 
   it('returns the message with the proper pass verbage', () => {
@@ -43,6 +43,6 @@ describe('toExist', () => {
 
     const truthyResults = toExist(shallow(<Test />));
 
-    expect(truthyResults.pass).toBeTruthy();
+    expect(truthyResults.pass).toBe(true);
   });
 });

--- a/packages/enzyme-matchers/src/assertions/__tests__/toHaveClassName.test.js
+++ b/packages/enzyme-matchers/src/assertions/__tests__/toHaveClassName.test.js
@@ -19,8 +19,8 @@ describe('toHaveClassName', () => {
       const falsyResults = toHaveClassName(wrapper.find('.bar'), 'asldfkj');
 
       it('returns the pass flag properly', () => {
-        expect(truthyResults.pass).toBeTruthy();
-        expect(falsyResults.pass).toBeFalsy();
+        expect(truthyResults.pass).toBe(true);
+        expect(falsyResults.pass).toBe(false);
       });
 
       it(`returns the message with the proper pass verbage (${builder.name})`, () => {

--- a/packages/enzyme-matchers/src/assertions/__tests__/toHaveDisplayName.test.js
+++ b/packages/enzyme-matchers/src/assertions/__tests__/toHaveDisplayName.test.js
@@ -18,8 +18,8 @@ describe('toHaveDisplayName', () => {
       const falsyResults = toHaveDisplayName(wrapper, 'span');
 
       it('returns the pass flag properly', () => {
-        expect(truthyResults.pass).toBeTruthy();
-        expect(falsyResults.pass).toBeFalsy();
+        expect(truthyResults.pass).toBe(true);
+        expect(falsyResults.pass).toBe(false);
       });
 
       it(`returns the message with the proper pass verbage (${builder.name})`, () => {

--- a/packages/enzyme-matchers/src/assertions/__tests__/toHaveHTML.test.js
+++ b/packages/enzyme-matchers/src/assertions/__tests__/toHaveHTML.test.js
@@ -28,9 +28,9 @@ describe('toHaveHTML', () => {
       const falsyResults = toHaveHTML(wrapper.find('#child'), 'foo');
 
       it('returns the pass flag properly', () => {
-        expect(truthyResults.pass).toBeTruthy();
-        expect(truthyMultilineResults.pass).toBeTruthy();
-        expect(falsyResults.pass).toBeFalsy();
+        expect(truthyResults.pass).toBe(true);
+        expect(truthyMultilineResults.pass).toBe(true);
+        expect(falsyResults.pass).toBe(false);
       });
 
       it(`returns the message with the proper pass verbage (${builder.name})`, () => {

--- a/packages/enzyme-matchers/src/assertions/__tests__/toHaveProp.test.js
+++ b/packages/enzyme-matchers/src/assertions/__tests__/toHaveProp.test.js
@@ -55,8 +55,8 @@ describe('toHaveProp', () => {
       it('returns the pass flag properly', () => {
         const { truthyResults, falsyResults } = build();
 
-        expect(truthyResults.pass).toBeTruthy();
-        expect(falsyResults.pass).toBeFalsy();
+        expect(truthyResults.pass).toBe(true);
+        expect(falsyResults.pass).toBe(false);
       });
 
       it(`returns the message with the proper pass verbage (${builder.name})`, () => {
@@ -80,8 +80,8 @@ describe('toHaveProp', () => {
         const truthy = toHaveProp(user, 'arrayProp', [1, 2, 3]);
         const falsy = toHaveProp(user, 'arrayProp', [4, 5, 6]);
 
-        expect(truthy.pass).toBeTruthy();
-        expect(falsy.pass).toBeFalsy();
+        expect(truthy.pass).toBe(true);
+        expect(falsy.pass).toBe(false);
       });
 
       it('can validate objects', () => {
@@ -90,15 +90,15 @@ describe('toHaveProp', () => {
         const truthy = toHaveProp(user, 'objectProp', { foo: 'bar' });
         const falsy = toHaveProp(user, 'objectProp', { foo: 'BOO' });
 
-        expect(truthy.pass).toBeTruthy();
-        expect(falsy.pass).toBeFalsy();
+        expect(truthy.pass).toBe(true);
+        expect(falsy.pass).toBe(false);
       });
 
       it('works with falsy props', () => {
         const wrapper = builder(<Fixture />);
         const { pass } = toHaveProp(wrapper.find(User), 'falsy', false);
 
-        expect(pass).toBeTruthy();
+        expect(pass).toBe(true);
       });
 
       it('works with functions', () => {
@@ -106,22 +106,22 @@ describe('toHaveProp', () => {
         const { pass } = toHaveProp(wrapper.find(User), 'fn', fn);
         const { pass: fail } = toHaveProp(wrapper.find(User), 'fn', () => {});
 
-        expect(pass).toBeTruthy();
-        expect(fail).toBeFalsy();
+        expect(pass).toBe(true);
+        expect(fail).toBe(false);
       });
 
       it('works without a prop value', () => {
         const wrapper = builder(<Fixture />);
         const truthy = toHaveProp(wrapper.find(User), 'name');
 
-        expect(truthy.pass).toBeTruthy();
+        expect(truthy.pass).toBe(true);
       });
 
       it('works with undefined value', () => {
         const wrapper = builder(<Fixture />);
         const falsy = toHaveProp(wrapper.find(User), 'name', undefined);
 
-        expect(falsy.pass).toBeFalsy();
+        expect(falsy.pass).toBe(false);
       });
     });
   });

--- a/packages/enzyme-matchers/src/assertions/__tests__/toHaveRef.test.js
+++ b/packages/enzyme-matchers/src/assertions/__tests__/toHaveRef.test.js
@@ -18,8 +18,8 @@ describe('toHaveRef', () => {
       const falsyResults = toHaveRef(wrapper, 'dad');
 
       it('returns the pass flag properly', () => {
-        expect(truthyResults.pass).toBeTruthy();
-        expect(falsyResults.pass).toBeFalsy();
+        expect(truthyResults.pass).toBe(true);
+        expect(falsyResults.pass).toBe(false);
       });
 
       it(`returns the message with the proper pass verbage (${builder.name})`, () => {

--- a/packages/enzyme-matchers/src/assertions/__tests__/toHaveState.test.js
+++ b/packages/enzyme-matchers/src/assertions/__tests__/toHaveState.test.js
@@ -32,8 +32,8 @@ describe('toHaveState', () => {
       it('returns the pass flag properly', () => {
         const { truthyResults, falsyResults } = build();
 
-        expect(truthyResults.pass).toBeTruthy();
-        expect(falsyResults.pass).toBeFalsy();
+        expect(truthyResults.pass).toBe(true);
+        expect(falsyResults.pass).toBe(false);
       });
 
       it(`returns the message with the proper pass verbage (${builder.name})`, () => {
@@ -56,8 +56,8 @@ describe('toHaveState', () => {
         const { pass } = toHaveState(wrapper, 'foo', false);
         const { pass: fail } = toHaveState(wrapper, 'foo', true);
 
-        expect(pass).toBeTruthy();
-        expect(fail).toBeFalsy();
+        expect(pass).toBe(true);
+        expect(fail).toBe(false);
       });
 
       it('can validate arrays', () => {
@@ -65,8 +65,8 @@ describe('toHaveState', () => {
         const { pass } = toHaveState(wrapper, 'array', [1, 2, 3]);
         const { pass: fail } = toHaveState(wrapper, 'array', [4, 5, 6]);
 
-        expect(pass).toBeTruthy();
-        expect(fail).toBeFalsy();
+        expect(pass).toBe(true);
+        expect(fail).toBe(false);
       });
 
       it('can validate objects', () => {
@@ -74,8 +74,8 @@ describe('toHaveState', () => {
         const { pass } = toHaveState(wrapper, 'object', { foo: 'bar' });
         const { pass: fail } = toHaveState(wrapper, 'object', { foo: 'NOPE' });
 
-        expect(pass).toBeTruthy();
-        expect(fail).toBeFalsy();
+        expect(pass).toBe(true);
+        expect(fail).toBe(false);
       });
 
       it('returns the pass flag properly', () => {
@@ -83,22 +83,22 @@ describe('toHaveState', () => {
         const truthyResults = toHaveState(wrapper, 'foo', false);
         const falsyResults = toHaveState(wrapper, 'foo', true);
 
-        expect(truthyResults.pass).toBeTruthy();
-        expect(falsyResults.pass).toBeFalsy();
+        expect(truthyResults.pass).toBe(true);
+        expect(falsyResults.pass).toBe(false);
       });
 
       it('works without a prop value', () => {
         const wrapper = builder(<Fixture />);
         const truthy = toHaveState(wrapper, 'foo');
 
-        expect(truthy.pass).toBeTruthy();
+        expect(truthy.pass).toBe(true);
       });
 
       it('works with undefined value', () => {
         const wrapper = builder(<Fixture />);
         const falsy = toHaveState(wrapper, 'foo', undefined);
 
-        expect(falsy.pass).toBeFalsy();
+        expect(falsy.pass).toBe(false);
       });
 
       it('should support object arguments', () => {
@@ -113,8 +113,8 @@ describe('toHaveState', () => {
           array: [1, 2, 3],
         });
 
-        expect(passResult.pass).toBeTruthy();
-        expect(failResult.pass).toBeFalsy();
+        expect(passResult.pass).toBe(true);
+        expect(failResult.pass).toBe(false);
       });
     });
   });

--- a/packages/enzyme-matchers/src/assertions/__tests__/toHaveStyle.test.js
+++ b/packages/enzyme-matchers/src/assertions/__tests__/toHaveStyle.test.js
@@ -18,8 +18,8 @@ describe('toHaveStyle', () => {
       const falsyResults = toHaveStyle(wrapper, 'height', '0');
 
       it('returns the pass flag properly', () => {
-        expect(truthyResults.pass).toBeTruthy();
-        expect(falsyResults.pass).toBeFalsy();
+        expect(truthyResults.pass).toBe(true);
+        expect(falsyResults.pass).toBe(false);
       });
 
       it(`returns the message with the proper pass verbage (${builder.name})`, () => {
@@ -63,8 +63,8 @@ describe('toHaveStyle', () => {
           display: 'block',
         });
 
-        expect(passResult.pass).toBeTruthy();
-        expect(failResult.pass).toBeFalsy();
+        expect(passResult.pass).toBe(true);
+        expect(failResult.pass).toBe(false);
       });
     });
 
@@ -78,8 +78,8 @@ describe('toHaveStyle', () => {
         const widthResult = toHaveStyle(wrapper, 'width', 10);
         const heightResult = toHaveStyle(wrapper, 'height', 20);
 
-        expect(widthResult.pass).toBeTruthy();
-        expect(heightResult.pass).toBeTruthy();
+        expect(widthResult.pass).toBe(true);
+        expect(heightResult.pass).toBe(true);
       });
 
       it('should override style properties', () => {
@@ -91,8 +91,8 @@ describe('toHaveStyle', () => {
         const colorResult = toHaveStyle(wrapper, 'backgroundColor', '#023c69');
         const widthResult = toHaveStyle(wrapper, 'width', null);
 
-        expect(colorResult.pass).toBeTruthy();
-        expect(widthResult.pass).toBeTruthy();
+        expect(colorResult.pass).toBe(true);
+        expect(widthResult.pass).toBe(true);
       });
 
       it('should overwrite properties with `undefined`', () => {
@@ -103,7 +103,7 @@ describe('toHaveStyle', () => {
 
         const colorResult = toHaveStyle(wrapper, 'backgroundColor', undefined);
 
-        expect(colorResult.pass).toBeTruthy();
+        expect(colorResult.pass).toBe(true);
       });
 
       it('should recursively flatten arrays', () => {
@@ -118,8 +118,8 @@ describe('toHaveStyle', () => {
         const widthResult = toHaveStyle(wrapper, 'width', 30);
         const heightResult = toHaveStyle(wrapper, 'height', 20);
 
-        expect(widthResult.pass).toBeTruthy();
-        expect(heightResult.pass).toBeTruthy();
+        expect(widthResult.pass).toBe(true);
+        expect(heightResult.pass).toBe(true);
       });
 
       it('should support object arguments', () => {
@@ -136,8 +136,8 @@ describe('toHaveStyle', () => {
           display: 'block',
         });
 
-        expect(passResult.pass).toBeTruthy();
-        expect(failResult.pass).toBeFalsy();
+        expect(passResult.pass).toBe(true);
+        expect(failResult.pass).toBe(false);
       });
     });
   });

--- a/packages/enzyme-matchers/src/assertions/__tests__/toHaveText.test.js
+++ b/packages/enzyme-matchers/src/assertions/__tests__/toHaveText.test.js
@@ -17,8 +17,8 @@ describe('toHaveText', () => {
       const falsyResults = toHaveText(wrapper, 'Turdz');
 
       it('returns the pass flag properly', () => {
-        expect(truthyResults.pass).toBeTruthy();
-        expect(falsyResults.pass).toBeFalsy();
+        expect(truthyResults.pass).toBe(true);
+        expect(falsyResults.pass).toBe(false);
       });
 
       it(`returns the message with the proper pass verbage (${builder.name})`, () => {

--- a/packages/enzyme-matchers/src/assertions/__tests__/toHaveValue.test.js
+++ b/packages/enzyme-matchers/src/assertions/__tests__/toHaveValue.test.js
@@ -17,8 +17,8 @@ describe('toHaveValue', () => {
       const falsyResults = toHaveValue(wrapper, 'Turdz');
 
       it('returns the pass flag properly', () => {
-        expect(truthyResults.pass).toBeTruthy();
-        expect(falsyResults.pass).toBeFalsy();
+        expect(truthyResults.pass).toBe(true);
+        expect(falsyResults.pass).toBe(false);
       });
 
       it(`returns the message with the proper pass verbage (${builder.name})`, () => {
@@ -36,9 +36,9 @@ describe('toHaveValue', () => {
 
     it('prioritizes `value` over `defaultValue`', () => {
       const _wrapper = shallow(<Fixture />).find('input').at(1);
-      expect(toHaveValue(_wrapper, 'bar').pass).toBeTruthy();
+      expect(toHaveValue(_wrapper, 'bar').pass).toBe(true);
 
-      expect(toHaveValue(_wrapper, 'foo').pass).toBeFalsy();
+      expect(toHaveValue(_wrapper, 'foo').pass).toBe(false);
     });
   });
 });

--- a/packages/enzyme-matchers/src/assertions/__tests__/toIncludeText.test.js
+++ b/packages/enzyme-matchers/src/assertions/__tests__/toIncludeText.test.js
@@ -16,8 +16,8 @@ describe('toIncludeText', () => {
       const falsyResults = toIncludeText(wrapper, 'nope');
 
       it('returns the pass flag properly', () => {
-        expect(truthyResults.pass).toBeTruthy();
-        expect(falsyResults.pass).toBeFalsy();
+        expect(truthyResults.pass).toBe(true);
+        expect(falsyResults.pass).toBe(false);
       });
 
       it(`returns the message with the proper pass verbage (${builder.name})`, () => {

--- a/packages/enzyme-matchers/src/assertions/__tests__/toMatchElement.test.js
+++ b/packages/enzyme-matchers/src/assertions/__tests__/toMatchElement.test.js
@@ -23,10 +23,10 @@ describe('toMatchElement', () => {
       });
 
       it('returns the pass flag properly', () => {
-        expect(truthyResults.pass).toBeTruthy();
-        expect(truthyResultsMatchSpan.pass).toBeTruthy();
-        expect(falsyResults.pass).toBeFalsy();
-        expect(truthyResultsIncludeProps.pass).toBeTruthy();
+        expect(truthyResults.pass).toBe(true);
+        expect(truthyResultsMatchSpan.pass).toBe(true);
+        expect(falsyResults.pass).toBe(false);
+        expect(truthyResultsIncludeProps.pass).toBe(true);
       });
 
       it('returns the message with the proper pass verbage', () => {

--- a/packages/enzyme-matchers/src/assertions/__tests__/toMatchSelector.test.js
+++ b/packages/enzyme-matchers/src/assertions/__tests__/toMatchSelector.test.js
@@ -16,8 +16,8 @@ describe('toMatchSelector', () => {
       const falsyResults = toMatchSelector(wrapper, '.doesnt-match');
 
       it('returns the pass flag properly', () => {
-        expect(truthyResults.pass).toBeTruthy();
-        expect(falsyResults.pass).toBeFalsy();
+        expect(truthyResults.pass).toBe(true);
+        expect(falsyResults.pass).toBe(false);
       });
 
       it(`returns the message with the proper pass verbage (${builder.name})`, () => {

--- a/packages/enzyme-matchers/src/assertions/toContainMatchingElement.js
+++ b/packages/enzyme-matchers/src/assertions/toContainMatchingElement.js
@@ -16,7 +16,7 @@ function toContainMatchingElement(
   selector: string
 ): Matcher {
   const matches = enzymeWrapper.find(selector);
-  const pass = matches.length;
+  const pass = matches.length > 0;
   const nodeName = getNodeName(enzymeWrapper);
 
   return {


### PR DESCRIPTION
`jest` is throwing an error on the `.toContainMatchingElement()` matcher (see output below). The easiest fix seems to stop using truthy return values for `pass` and using an explicit `> 0` operator to return boolean `true/false` rather than `0` or something `>0`.

Possibly related to #276.

I've created a minimal example repository to reproduce this issue:
https://github.com/shawyu/enzyme-matchers-example

which produces this output:

```
$ npm test

> enzyme-matchers-example@1.0.0 test /Users/shawyu/external/enzyme-matchers-example
> jest example.test.js

 FAIL  ./example.test.js
  failing test
    ✕ runs (16ms)

  ● failing test › runs

    Unexpected return from a matcher function.
    Matcher functions should return an object in the following format:
      {message?: string | function, pass: boolean}
    '{"contextualInformation": {"actual": "HTML Output of <div>:
     <div><ul><li>Item</li></ul></div>"}, "message": [Function message], "negatedMessage": "Expected <div> to not contain an element matching ul but it did.", "pass": 1}' was returned

      17 |     const wrapper = shallow(<List />);
      18 |
    > 19 |     expect(wrapper).toContainMatchingElement('ul');
         |                     ^
      20 |   });
      21 | });
      22 |

      at _validateResult (node_modules/expect/build/index.js:364:11)
      at processResult (node_modules/expect/build/index.js:261:7)
      at Object.throwingMatcher [as toContainMatchingElement] (node_modules/expect/build/index.js:331:16)
      at Object.toContainMatchingElement (example.test.js:19:21)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 1 total
Snapshots:   0 total
Time:        1.163s
Ran all test suites matching /example.test.js/i.
npm ERR! Test failed.  See above for more details.
```