### PR TITLE
Updated setup instructions

### DIFF
--- a/packages/jest-enzyme/README.md
+++ b/packages/jest-enzyme/README.md
@@ -19,7 +19,7 @@ If you prefer not to use the environment, you can also do this:
 ```js
 // package.json
 "jest": {
-  "setupTestFrameworkScriptFile": "./node_modules/jest-enzyme/lib/index.js",
+  "setupFilesAfterEnv": ['./node_modules/jest-enzyme/lib/index.js'],
 }
 ```
 


### PR DESCRIPTION
Replace deprecated `setupTestFrameworkScriptFile` wtih `setupFilesAfterEnv` in setup instructions

RE discussion in #86 