### PR TITLE
Clearer example of how to install adapter

### DIFF
--- a/packages/jest-environment-enzyme/README.md
+++ b/packages/jest-environment-enzyme/README.md
@@ -11,10 +11,16 @@ This package will also simplify your test files by declaring React, and enzyme w
 The setup can be as simple as this:
 
 ```
-yarn add jest-environment-enzyme jest-enzyme enzyme-adapter-* --dev
+yarn add jest-environment-enzyme jest-enzyme enzyme-adapter-react-* --dev
 ```
 
 > (Where * is your app's adapter that matches your React version)
+
+For example, if you are using react-16, it should look like:
+
+```
+yarn add jest-environment-enzyme jest-enzyme enzyme-adapter-react-16 --dev
+```
 
 ```js
 // package.json


### PR DESCRIPTION
I tripped on adding

```
yarn add jest-environment-enzyme jest-enzyme enzyme-adapter-16 --dev
```

Instead of 
```
yarn add jest-environment-enzyme jest-enzyme enzyme-adapter-react-16 --dev
```

So I added a line to clarify this.