### PR TITLE
Update jest-environment-jsdom

### DIFF
--- a/packages/jest-environment-enzyme/package.json
+++ b/packages/jest-environment-enzyme/package.json
@@ -45,7 +45,7 @@
     "react": "^0.13.0 || ^0.14.0 || ^15.0.0 || >=16.x"
   },
   "dependencies": {
-    "jest-environment-jsdom": "^22.4.1"
+    "jest-environment-jsdom": "^24.0.0"
   },
   "babel": {
     "presets": [


### PR DESCRIPTION
Fixes #295
Update to the latest version of `jest-environment-jsdom` (24.0.0) to patch vulnerability in `braces` (requires >= 2.3.1)