### PR TITLE
Fix Assertions link in Jest-Enzyme README

### DIFF
--- a/packages/jest-enzyme/README.md
+++ b/packages/jest-enzyme/README.md
@@ -5,7 +5,7 @@
 
 **Quick Links**
 * [Setup](#setup)
-* [Assertions](#matchers)
+* [Assertions](#assertions)
 * [Jest Enzyme Environment](#jest-enzyme-environment)
 * [Create React App](#usage-with-create-react-app)
 * [Typescript](#usage-with-typescript)


### PR DESCRIPTION
Currently, the Jest-Enzyme README has a broken link for 'Assertions' in Quick Links. This PR fixes that link.