### PR TITLE
Allowing some assertions to be called on lists of nodes

### DIFF
--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainExactlyOneMatchingElement.test.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainExactlyOneMatchingElement.test.js.snap
@@ -14,12 +14,23 @@ Object {
 }
 `;
 
+exports[`toContainExactlyOneMatchingElement provides contextual information for the message 3`] = `
+Object {
+  "actual": "HTML Output of <ul>:
+ <ul><li><User index={1} className=\\"userOne\\" /></li><li><User index={2} className=\\"userTwo\\" /></li></ul>",
+}
+`;
+
 exports[`toContainExactlyOneMatchingElement returns the message with the proper fail verbage 1`] = `"Expected <div> to not contain 1 element matching User but it did."`;
 
 exports[`toContainExactlyOneMatchingElement returns the message with the proper fail verbage 2`] = `"Expected <div> to not contain 1 element matching .userThree but it did."`;
 
 exports[`toContainExactlyOneMatchingElement returns the message with the proper fail verbage 3`] = `"Expected <div> to not contain 1 element matching [index] but it did."`;
 
+exports[`toContainExactlyOneMatchingElement returns the message with the proper fail verbage 4`] = `"Expected <ul> to not contain 1 element matching [index] but it did."`;
+
 exports[`toContainExactlyOneMatchingElement returns the message with the proper pass verbage 1`] = `"Expected <div> to contain 1 element matching .userOne but 1 was found."`;
 
 exports[`toContainExactlyOneMatchingElement returns the message with the proper pass verbage 2`] = `"Expected <div> to contain 1 element matching [index=1] but 1 was found."`;
+
+exports[`toContainExactlyOneMatchingElement returns the message with the proper pass verbage 3`] = `"Expected <ul> to contain 1 element matching [index=1] but 1 was found."`;

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainMatchingElement.test.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainMatchingElement.test.js.snap
@@ -21,12 +21,23 @@ Object {
 }
 `;
 
+exports[`toContainMatchingElement provides contextual information for the message 4`] = `
+Object {
+  "actual": "HTML Output of <ul>:
+ <ul><li><User index={1} className=\\"userOne\\" /></li><li><User index={2} className=\\"userTwo\\" /></li></ul>",
+}
+`;
+
 exports[`toContainMatchingElement returns the message with the proper fail verbage 1`] = `"Expected <div> to not contain an element matching Foo but it did."`;
 
 exports[`toContainMatchingElement returns the message with the proper fail verbage 2`] = `"Expected <div> to not contain an element matching .userThree but it did."`;
+
+exports[`toContainMatchingElement returns the message with the proper fail verbage 3`] = `"Expected <ul> to not contain an element matching Bar but it did."`;
 
 exports[`toContainMatchingElement returns the message with the proper pass verbage 1`] = `"Expected <div> to contain at least one element matching User but none were found."`;
 
 exports[`toContainMatchingElement returns the message with the proper pass verbage 2`] = `"Expected <div> to contain at least one element matching [index=1] but none were found."`;
 
 exports[`toContainMatchingElement returns the message with the proper pass verbage 3`] = `"Expected <div> to contain at least one element matching [index] but none were found."`;
+
+exports[`toContainMatchingElement returns the message with the proper pass verbage 4`] = `"Expected <ul> to contain at least one element matching [index] but none were found."`;

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainMatchingElements.test.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainMatchingElements.test.js.snap
@@ -21,14 +21,49 @@ Object {
 }
 `;
 
+exports[`toContainMatchingElements provides contextual information for the message 4`] = `
+Object {
+  "actual": "HTML Output of <ul>:
+ <ul><li><User index={1} className=\\"userOne\\" /></li><li><User index={2} className=\\"userTwo\\" /></li></ul>",
+}
+`;
+
+exports[`toContainMatchingElements provides contextual information for the message 5`] = `
+Object {
+  "actual": "HTML Output of <2 (anonymous) nodes found>:
+ Multiple nodes found:
+0: <function User(props) {
+  return (
+    /* istanbul ignore next */React.createElement( /* istanbul ignore next */'span', /* istanbul ignore next */{ className: props.className }, /* istanbul ignore next */'User ',
+      props.index));
+
+
+} index=\\"1\\" className=\\"userOne\\"/>
+1: <function User(props) {
+  return (
+    /* istanbul ignore next */React.createElement( /* istanbul ignore next */'span', /* istanbul ignore next */{ className: props.className }, /* istanbul ignore next */'User ',
+      props.index));
+
+
+} index=\\"2\\" className=\\"userTwo\\"/>
+",
+}
+`;
+
 exports[`toContainMatchingElements returns the message with the proper fail verbage 1`] = `"Expected <div> to not contain 3 elements matching User but it did."`;
 
 exports[`toContainMatchingElements returns the message with the proper fail verbage 2`] = `"Expected <div> to not contain 1 element matching .userThree but it did."`;
 
 exports[`toContainMatchingElements returns the message with the proper fail verbage 3`] = `"Expected <div> to not contain 1 element matching [index] but it did."`;
 
+exports[`toContainMatchingElements returns the message with the proper fail verbage 4`] = `"Expected <ul> to not contain 3 elements matching [index] but it did."`;
+
 exports[`toContainMatchingElements returns the message with the proper pass verbage 1`] = `"Expected <div> to contain 2 elements matching User but 2 were found."`;
 
 exports[`toContainMatchingElements returns the message with the proper pass verbage 2`] = `"Expected <div> to contain 1 element matching [index=1] but 1 was found."`;
 
 exports[`toContainMatchingElements returns the message with the proper pass verbage 3`] = `"Expected <div> to contain 2 elements matching [index] but 2 were found."`;
+
+exports[`toContainMatchingElements returns the message with the proper pass verbage 4`] = `"Expected <ul> to contain 2 elements matching [index] but 2 were found."`;
+
+exports[`toContainMatchingElements returns the message with the proper pass verbage 5`] = `"Expected <2 (anonymous) nodes found> to contain 1 element matching [index=1] but 1 was found."`;

--- a/packages/enzyme-matchers/src/assertions/__tests__/toContainExactlyOneMatchingElement.test.js
+++ b/packages/enzyme-matchers/src/assertions/__tests__/toContainExactlyOneMatchingElement.test.js
@@ -34,11 +34,13 @@ describe('toContainExactlyOneMatchingElement', () => {
   const truthyResults = [
     toContainExactlyOneMatchingElement(wrapper, '.userOne'),
     toContainExactlyOneMatchingElement(wrapper, '[index=1]'),
+    toContainExactlyOneMatchingElement(wrapper.find('ul'), '[index=1]'),
   ];
   const falsyResults = [
     toContainExactlyOneMatchingElement(wrapper, 'User'),
     toContainExactlyOneMatchingElement(wrapper, '.userThree'),
     toContainExactlyOneMatchingElement(wrapper, '[index]'),
+    toContainExactlyOneMatchingElement(wrapper.find('ul'), '[index]'),
   ];
 
   it('returns the pass flag properly', () => {

--- a/packages/enzyme-matchers/src/assertions/__tests__/toContainMatchingElement.test.js
+++ b/packages/enzyme-matchers/src/assertions/__tests__/toContainMatchingElement.test.js
@@ -36,10 +36,12 @@ describe('toContainMatchingElement', () => {
     toContainMatchingElement(wrapper, 'User'),
     toContainMatchingElement(wrapper, '[index=1]'),
     toContainMatchingElement(wrapper, '[index]'),
+    toContainMatchingElement(wrapper.find('ul'), '[index]'),
   ];
   const falsyResults = [
     toContainMatchingElement(wrapper, 'Foo'),
     toContainMatchingElement(wrapper, '.userThree'),
+    toContainMatchingElement(wrapper.find('ul'), 'Bar'),
   ];
 
   it('returns the pass flag properly', () => {

--- a/packages/enzyme-matchers/src/assertions/__tests__/toContainMatchingElements.test.js
+++ b/packages/enzyme-matchers/src/assertions/__tests__/toContainMatchingElements.test.js
@@ -36,11 +36,14 @@ describe('toContainMatchingElements', () => {
     toContainMatchingElements(wrapper, 2, 'User'),
     toContainMatchingElements(wrapper, 1, '[index=1]'),
     toContainMatchingElements(wrapper, 2, '[index]'),
+    toContainMatchingElements(wrapper.find('ul'), 2, '[index]'),
+    toContainMatchingElements(wrapper.find('User'), 1, '[index=1]'),
   ];
   const falsyResults = [
     toContainMatchingElements(wrapper, 3, 'User'),
     toContainMatchingElements(wrapper, 1, '.userThree'),
     toContainMatchingElements(wrapper, 1, '[index]'),
+    toContainMatchingElements(wrapper.find('ul'), 3, '[index]'),
   ];
 
   it('returns the pass flag properly', () => {

--- a/packages/enzyme-matchers/src/assertions/toContainMatchingElement.js
+++ b/packages/enzyme-matchers/src/assertions/toContainMatchingElement.js
@@ -9,7 +9,6 @@
 import type { EnzymeObject, Matcher } from '../types';
 import html from '../utils/html';
 import getNodeName from '../utils/name';
-import single from '../utils/single';
 
 function toContainMatchingElement(
   enzymeWrapper: EnzymeObject,
@@ -33,4 +32,4 @@ function toContainMatchingElement(
   };
 }
 
-export default single(toContainMatchingElement);
+export default toContainMatchingElement;

--- a/packages/enzyme-matchers/src/assertions/toContainMatchingElements.js
+++ b/packages/enzyme-matchers/src/assertions/toContainMatchingElements.js
@@ -9,7 +9,6 @@
 import type { EnzymeObject, Matcher } from '../types';
 import html from '../utils/html';
 import getNodeName from '../utils/name';
-import single from '../utils/single';
 
 function toContainMatchingElements(
   enzymeWrapper: EnzymeObject,
@@ -36,4 +35,4 @@ function toContainMatchingElements(
   };
 }
 
-export default single(toContainMatchingElements);
+export default toContainMatchingElements;


### PR DESCRIPTION
When I added the `toContainMatchingElement(s)` assertions I copy / pasted code from another assertion that included the `single` assertion. Looking closer, it isn't necessary here since enzyme allows calling `.find` on element lists, so this change removes it.