### PR TITLE
Better messaging for component selectors

### DIFF
--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainExactlyOneMatchingElement.test.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainExactlyOneMatchingElement.test.js.snap
@@ -21,16 +21,16 @@ Object {
 }
 `;
 
-exports[`toContainExactlyOneMatchingElement returns the message with the proper fail verbage 1`] = `"Expected <div> to not contain 1 element matching User but it did."`;
+exports[`toContainExactlyOneMatchingElement returns the message with the proper fail verbage 1`] = `"Expected <div> to not contain 1 element matching \\"User\\" but it did."`;
 
-exports[`toContainExactlyOneMatchingElement returns the message with the proper fail verbage 2`] = `"Expected <div> to not contain 1 element matching .userThree but it did."`;
+exports[`toContainExactlyOneMatchingElement returns the message with the proper fail verbage 2`] = `"Expected <div> to not contain 1 element matching \\".userThree\\" but it did."`;
 
-exports[`toContainExactlyOneMatchingElement returns the message with the proper fail verbage 3`] = `"Expected <div> to not contain 1 element matching [index] but it did."`;
+exports[`toContainExactlyOneMatchingElement returns the message with the proper fail verbage 3`] = `"Expected <div> to not contain 1 element matching \\"[index]\\" but it did."`;
 
-exports[`toContainExactlyOneMatchingElement returns the message with the proper fail verbage 4`] = `"Expected <ul> to not contain 1 element matching [index] but it did."`;
+exports[`toContainExactlyOneMatchingElement returns the message with the proper fail verbage 4`] = `"Expected <ul> to not contain 1 element matching \\"[index]\\" but it did."`;
 
-exports[`toContainExactlyOneMatchingElement returns the message with the proper pass verbage 1`] = `"Expected <div> to contain 1 element matching .userOne but 1 was found."`;
+exports[`toContainExactlyOneMatchingElement returns the message with the proper pass verbage 1`] = `"Expected <div> to contain 1 element matching \\".userOne\\" but 1 was found."`;
 
-exports[`toContainExactlyOneMatchingElement returns the message with the proper pass verbage 2`] = `"Expected <div> to contain 1 element matching [index=1] but 1 was found."`;
+exports[`toContainExactlyOneMatchingElement returns the message with the proper pass verbage 2`] = `"Expected <div> to contain 1 element matching \\"[index=1]\\" but 1 was found."`;
 
-exports[`toContainExactlyOneMatchingElement returns the message with the proper pass verbage 3`] = `"Expected <ul> to contain 1 element matching [index=1] but 1 was found."`;
+exports[`toContainExactlyOneMatchingElement returns the message with the proper pass verbage 3`] = `"Expected <ul> to contain 1 element matching \\"[index=1]\\" but 1 was found."`;

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainMatchingElement.test.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainMatchingElement.test.js.snap
@@ -28,16 +28,16 @@ Object {
 }
 `;
 
-exports[`toContainMatchingElement returns the message with the proper fail verbage 1`] = `"Expected <div> to not contain an element matching Foo but it did."`;
+exports[`toContainMatchingElement returns the message with the proper fail verbage 1`] = `"Expected <div> to not contain an element matching \\"Foo\\" but it did."`;
 
-exports[`toContainMatchingElement returns the message with the proper fail verbage 2`] = `"Expected <div> to not contain an element matching .userThree but it did."`;
+exports[`toContainMatchingElement returns the message with the proper fail verbage 2`] = `"Expected <div> to not contain an element matching \\".userThree\\" but it did."`;
 
-exports[`toContainMatchingElement returns the message with the proper fail verbage 3`] = `"Expected <ul> to not contain an element matching Bar but it did."`;
+exports[`toContainMatchingElement returns the message with the proper fail verbage 3`] = `"Expected <ul> to not contain an element matching \\"Bar\\" but it did."`;
 
-exports[`toContainMatchingElement returns the message with the proper pass verbage 1`] = `"Expected <div> to contain at least one element matching User but none were found."`;
+exports[`toContainMatchingElement returns the message with the proper pass verbage 1`] = `"Expected <div> to contain at least one element matching \\"User\\" but none were found."`;
 
-exports[`toContainMatchingElement returns the message with the proper pass verbage 2`] = `"Expected <div> to contain at least one element matching [index=1] but none were found."`;
+exports[`toContainMatchingElement returns the message with the proper pass verbage 2`] = `"Expected <div> to contain at least one element matching \\"[index=1]\\" but none were found."`;
 
-exports[`toContainMatchingElement returns the message with the proper pass verbage 3`] = `"Expected <div> to contain at least one element matching [index] but none were found."`;
+exports[`toContainMatchingElement returns the message with the proper pass verbage 3`] = `"Expected <div> to contain at least one element matching \\"[index]\\" but none were found."`;
 
-exports[`toContainMatchingElement returns the message with the proper pass verbage 4`] = `"Expected <ul> to contain at least one element matching [index] but none were found."`;
+exports[`toContainMatchingElement returns the message with the proper pass verbage 4`] = `"Expected <ul> to contain at least one element matching \\"[index]\\" but none were found."`;

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainMatchingElements.test.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainMatchingElements.test.js.snap
@@ -50,20 +50,20 @@ Object {
 }
 `;
 
-exports[`toContainMatchingElements returns the message with the proper fail verbage 1`] = `"Expected <div> to not contain 3 elements matching User but it did."`;
+exports[`toContainMatchingElements returns the message with the proper fail verbage 1`] = `"Expected <div> to not contain 3 elements matching \\"User\\" but it did."`;
 
-exports[`toContainMatchingElements returns the message with the proper fail verbage 2`] = `"Expected <div> to not contain 1 element matching .userThree but it did."`;
+exports[`toContainMatchingElements returns the message with the proper fail verbage 2`] = `"Expected <div> to not contain 1 element matching \\".userThree\\" but it did."`;
 
-exports[`toContainMatchingElements returns the message with the proper fail verbage 3`] = `"Expected <div> to not contain 1 element matching [index] but it did."`;
+exports[`toContainMatchingElements returns the message with the proper fail verbage 3`] = `"Expected <div> to not contain 1 element matching \\"[index]\\" but it did."`;
 
-exports[`toContainMatchingElements returns the message with the proper fail verbage 4`] = `"Expected <ul> to not contain 3 elements matching [index] but it did."`;
+exports[`toContainMatchingElements returns the message with the proper fail verbage 4`] = `"Expected <ul> to not contain 3 elements matching \\"[index]\\" but it did."`;
 
-exports[`toContainMatchingElements returns the message with the proper pass verbage 1`] = `"Expected <div> to contain 2 elements matching User but 2 were found."`;
+exports[`toContainMatchingElements returns the message with the proper pass verbage 1`] = `"Expected <div> to contain 2 elements matching \\"User\\" but 2 were found."`;
 
-exports[`toContainMatchingElements returns the message with the proper pass verbage 2`] = `"Expected <div> to contain 1 element matching [index=1] but 1 was found."`;
+exports[`toContainMatchingElements returns the message with the proper pass verbage 2`] = `"Expected <div> to contain 1 element matching \\"[index=1]\\" but 1 was found."`;
 
-exports[`toContainMatchingElements returns the message with the proper pass verbage 3`] = `"Expected <div> to contain 2 elements matching [index] but 2 were found."`;
+exports[`toContainMatchingElements returns the message with the proper pass verbage 3`] = `"Expected <div> to contain 2 elements matching \\"[index]\\" but 2 were found."`;
 
-exports[`toContainMatchingElements returns the message with the proper pass verbage 4`] = `"Expected <ul> to contain 2 elements matching [index] but 2 were found."`;
+exports[`toContainMatchingElements returns the message with the proper pass verbage 4`] = `"Expected <ul> to contain 2 elements matching \\"[index]\\" but 2 were found."`;
 
-exports[`toContainMatchingElements returns the message with the proper pass verbage 5`] = `"Expected <2 (anonymous) nodes found> to contain 1 element matching [index=1] but 1 was found."`;
+exports[`toContainMatchingElements returns the message with the proper pass verbage 5`] = `"Expected <2 (anonymous) nodes found> to contain 1 element matching \\"[index=1]\\" but 1 was found."`;

--- a/packages/enzyme-matchers/src/assertions/toContainMatchingElement.js
+++ b/packages/enzyme-matchers/src/assertions/toContainMatchingElement.js
@@ -8,6 +8,7 @@
 
 import type { EnzymeObject, Matcher } from '../types';
 import html from '../utils/html';
+import getDisplayName from '../utils/displayName';
 import getNodeName from '../utils/name';
 
 function toContainMatchingElement(
@@ -22,10 +23,10 @@ function toContainMatchingElement(
     pass,
     message:
       `Expected <${nodeName}> to contain at least one element matching ` +
-      `${selector} but none were found.`,
+      `"${getDisplayName(selector)}" but none were found.`,
     negatedMessage:
       `Expected <${nodeName}> to not contain an element matching ` +
-      `${selector} but it did.`,
+      `"${getDisplayName(selector)}" but it did.`,
     contextualInformation: {
       actual: `HTML Output of <${nodeName}>:\n ${html(enzymeWrapper)}`,
     },

--- a/packages/enzyme-matchers/src/assertions/toContainMatchingElements.js
+++ b/packages/enzyme-matchers/src/assertions/toContainMatchingElements.js
@@ -8,6 +8,7 @@
 
 import type { EnzymeObject, Matcher } from '../types';
 import html from '../utils/html';
+import getDisplayName from '../utils/displayName';
 import getNodeName from '../utils/name';
 
 function toContainMatchingElements(
@@ -25,10 +26,13 @@ function toContainMatchingElements(
       `Expected <${nodeName}> to contain ${n} element${n === 1
         ? ''
         : 's'} matching ` +
-      `${selector} but ${matches.length} ${n === 1 ? 'was' : 'were'} found.`,
+      `"${getDisplayName(selector)}" but ${matches.length} ${matches.length ===
+      1
+        ? 'was'
+        : 'were'} found.`,
     negatedMessage: `Expected <${nodeName}> to not contain ${n} element${n === 1
       ? ''
-      : 's'} matching ${selector} but it did.`,
+      : 's'} matching "${getDisplayName(selector)}" but it did.`,
     contextualInformation: {
       actual: `HTML Output of <${nodeName}>:\n ${html(enzymeWrapper)}`,
     },

--- a/packages/enzyme-matchers/src/utils/displayName.js
+++ b/packages/enzyme-matchers/src/utils/displayName.js
@@ -1,0 +1,11 @@
+// @flow
+
+export default function getDisplayName(Component: Function | string): string {
+  if (typeof Component === 'string') {
+    return Component;
+  }
+  if (!Component) {
+    return undefined;
+  }
+  return Component.displayName || Component.name || 'Component';
+}


### PR DESCRIPTION
This change improves the messaging when a component is passed as a selector. I also noticed the "were" / "was" selection was off for `toContainMatchingElements`, so I fixed that in this PR as well.

Using this test:

```jsx
function Song({id, title, lyrics}) {
    return (
        <dl id={`song-${id}`}>
            {title && <dt className="title">{title}</dt>}
            {lyrics && <dd className="lyrics">{lyrics}</dd>}
        </dl>
    );
}
expect(
    <SongList>{songs.map(song => <Song {...song} /></SongList>
).toContainMatchingElements(3, Song);
```

Output before this change:

```
Expected <SongList> to contain 3 elements matching function Song(_ref) {
    var id = _ref.id,
        title = _ref.title,
        lyrics = _ref.lyrics;

    return _get__('React').createElement(
        'dl',
        { id: 'song-' + id },
        title && _get__('React').createElement(
            'dt',
            { className: 'title' },
            title
        ),
        lyrics && _get__('React').createElement(
            'dd',
            { className: 'lyrics' },
            lyrics
        )
    );
} but 1 were found.
HTML Output of <SongList>:
<SongList><Song title="I\'m a Little Teapot" lyrics="I\'m a Little Teapot, short and stout." /></SongList>
```

Output with this change

```
Expected <SongList> to contain 3 elements matching "Song" but 1 was found.
HTML Output of <SongList>:
<SongList><Song title="I\'m a Little Teapot" lyrics="I\'m a Little Teapot, short and stout." /></SongList>
```
