### PR TITLE
Replace setupTestFrameworkScriptFile with setupFilesAfterEnv in jest-environment-enzyme README.md

### DIFF
--- a/packages/jest-environment-enzyme/README.md
+++ b/packages/jest-environment-enzyme/README.md
@@ -25,7 +25,7 @@ yarn add jest-environment-enzyme jest-enzyme enzyme-adapter-react-16 --dev
 ```js
 // package.json
 "jest": {
-  "setupTestFrameworkScriptFile": "jest-enzyme",
+  "setupFilesAfterEnv": ["jest-enzyme"],
   "testEnvironment": "enzyme"
 }
 ```
@@ -43,7 +43,7 @@ Valid options are:
 ```js
 // package.json
 "jest": {
-  "setupTestFrameworkScriptFile": "jest-enzyme",
+  "setupFilesAfterEnv": ["jest-enzyme"],
   "testEnvironment": "enzyme",
   "testEnvironmentOptions": {
     "enzymeAdapter": "react16"


### PR DESCRIPTION
`setupTestFrameworkScriptFile` was deprecated in favor of `setupFilesAfterEnv`.
> Note: setupTestFrameworkScriptFile is deprecated in favor of setupFilesAfterEnv.

https://jestjs.io/docs/en/configuration#setupfilesafterenv-array

https://github.com/FormidableLabs/enzyme-matchers/pull/312#issuecomment-537770203
> I'm curious, do we need to change anything for jest-environment-enzyme then?