### PR TITLE
Use setupFilesAfterEnv instead of setupTestFrameworkScriptFile

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,9 @@
     "testEnvironmentOptions": {
       "enzymeAdapter": "react16"
     },
-    "setupTestFrameworkScriptFile": "<rootDir>/packages/jest-enzyme/src/index.js",
+    "setupFilesAfterEnv": [
+      "<rootDir>/packages/jest-enzyme/src/index.js"
+    ],
     "roots": [
       "<rootDir>/packages/jasmine-enzyme/src",
       "<rootDir>/packages/jest-enzyme/src",

--- a/packages/enzyme-matchers/package.json
+++ b/packages/enzyme-matchers/package.json
@@ -45,7 +45,9 @@
     "roots": [
       "<rootDir>/src"
     ],
-    "setupTestFrameworkScriptFile": "../jest-enzyme/lib/index.js",
+    "setupFilesAfterEnv": [
+      "../jest-enzyme/lib/index.js"
+    ],
     "testEnvironment": "../jest-environment-enzyme/lib/index.js",
     "testEnvironmentOptions": {
       "adapter": "react16"

--- a/packages/jasmine-enzyme/package.json
+++ b/packages/jasmine-enzyme/package.json
@@ -53,7 +53,9 @@
     "transform": {
       "^.+\\.js$": "../../babel-jest-root-mode-wrapper.js"
     },
-    "setupTestFrameworkScriptFile": "jest-enzyme/src/index.js",
+    "setupFilesAfterEnv": [
+      "jest-enzyme/src/index.js"
+    ],
     "testEnvironment": "enzyme",
     "roots": [
       "<rootDir>/src"

--- a/packages/jest-enzyme/package.json
+++ b/packages/jest-enzyme/package.json
@@ -70,7 +70,9 @@
     "testEnvironmentOptions": {
       "enzymeAdapter": "react16"
     },
-    "setupTestFrameworkScriptFile": "<rootDir>/src/index.js",
+    "setupFilesAfterEnv": [
+      "<rootDir>/src/index.js"
+    ],
     "testRegex": "/(__tests__|__failing_tests__)/.*\\.test\\.js$",
     "transformIgnorePatterns": [
       "<rootDir>/node_modules/(?!enzyme-matchers)"

--- a/packages/jest-enzyme/src/index.js
+++ b/packages/jest-enzyme/src/index.js
@@ -3,7 +3,7 @@
  * This source code is licensed under the MIT-style license found in the
  * LICENSE file in the root directory of this source tree. *
  *
- * @providesModule setupTestFrameworkScriptFile
+ * @providesModule setupFilesAfterEnv
  * @flow
  */
 


### PR DESCRIPTION
From https://github.com/FormidableLabs/enzyme-matchers/pull/313#issuecomment-538447718:
> implementing this change to verify that it all works correctly still?