### PR TITLE
Update jests "Matchers" interface

### DIFF
--- a/packages/jest-enzyme/src/index.d.ts
+++ b/packages/jest-enzyme/src/index.d.ts
@@ -4,7 +4,7 @@ declare namespace jest {
     interface ToMatchElementOptions {
         ignoreProps?: boolean;
     }
-    interface Matchers<R> {
+    interface Matchers<R, T> {
         toBeChecked(): void;
         toBeDisabled(): void;
         toBeEmptyRender(): void;


### PR DESCRIPTION
closes https://github.com/FormidableLabs/enzyme-matchers/issues/318

the `Matchers` type of definitelytyped's jest package have been updated with https://github.com/DefinitelyTyped/DefinitelyTyped/pull/39243, which causes a compilation error since the interfaces don't match anymore.

See: https://github.com/testing-library/jest-dom/issues/152 or https://github.com/styled-components/jest-styled-components/pull/270

This PR changes the type to match the new one.