### PR TITLE
Fix babel target to es5

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,12 +1,5 @@
 const presets = [
-  [
-    '@babel/preset-env',
-    {
-      targets: {
-        node: 'current',
-      },
-    },
-  ],
+  '@babel/preset-env',
   '@babel/preset-react',
   '@babel/preset-flow',
 ];


### PR DESCRIPTION
close #329

This PR fixes the babel target so that it works on legacy browsers.