### PR TITLE
Update package.json settings in README

### DIFF
--- a/packages/jest-enzyme/README.md
+++ b/packages/jest-enzyme/README.md
@@ -19,7 +19,8 @@ If you prefer not to use the environment, you can also do this:
 ```js
 // package.json
 "jest": {
-  "setupFilesAfterEnv": ['./node_modules/jest-enzyme/lib/index.js'],
+  "testEnvironment": "enzyme",
+  "setupFilesAfterEnv": "./node_modules/jest-enzyme/lib/index.js",
 }
 ```
 


### PR DESCRIPTION
The syntax in the current README, specifying what to add to package.json, isn't valid json syntax and doesn't match the addition [suggested in the blog post](https://formidable.com/blog/2018/assertions-and-testing-with-enzyme-matchers-6/). This updates the documentation here to align with the blog post.