### PR TITLE
Fixing output not matching how enzyme wrappers are matched

### DIFF
--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toBeEmptyRender.test.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toBeEmptyRender.test.js.snap
@@ -2,7 +2,11 @@
 
 exports[`toBeEmptyRender provides contextual information for the message 1`] = `
 Object {
-  "actual": "Found Nodes HTML output: <div></div>",
+  "actual": "Found Nodes HTML output: <NonEmptyRenderFixture>
+  <div>
+    <EmptyRenderFixture />
+  </div>
+</NonEmptyRenderFixture>",
 }
 `;
 

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainExactlyOneMatchingElement.test.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainExactlyOneMatchingElement.test.js.snap
@@ -2,22 +2,47 @@
 
 exports[`toContainExactlyOneMatchingElement provides contextual information for the message 1`] = `
 Object {
-  "actual": "HTML Output of <div>:
- <div><ul><li><User index={1} className=\\"userOne\\" /></li><li><User index={2} className=\\"userTwo\\" /></li></ul></div>",
+  "actual": "Element tree for <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
 }
 `;
 
 exports[`toContainExactlyOneMatchingElement provides contextual information for the message 2`] = `
 Object {
-  "actual": "HTML Output of <div>:
- <div><ul><li><User index={1} className=\\"userOne\\" /></li><li><User index={2} className=\\"userTwo\\" /></li></ul></div>",
+  "actual": "Element tree for <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
 }
 `;
 
 exports[`toContainExactlyOneMatchingElement provides contextual information for the message 3`] = `
 Object {
-  "actual": "HTML Output of <ul>:
- <ul><li><User index={1} className=\\"userOne\\" /></li><li><User index={2} className=\\"userTwo\\" /></li></ul>",
+  "actual": "Element tree for <ul>:
+ <ul>
+  <li>
+    <User index={1} className=\\"userOne\\" />
+  </li>
+  <li>
+    <User index={2} className=\\"userTwo\\" />
+  </li>
+</ul>",
 }
 `;
 

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainMatchingElement.test.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainMatchingElement.test.js.snap
@@ -2,29 +2,63 @@
 
 exports[`toContainMatchingElement provides contextual information for the message 1`] = `
 Object {
-  "actual": "HTML Output of <div>:
- <div><ul><li><User index={1} className=\\"userOne\\" /></li><li><User index={2} className=\\"userTwo\\" /></li></ul></div>",
+  "actual": "Element tree for <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
 }
 `;
 
 exports[`toContainMatchingElement provides contextual information for the message 2`] = `
 Object {
-  "actual": "HTML Output of <div>:
- <div><ul><li><User index={1} className=\\"userOne\\" /></li><li><User index={2} className=\\"userTwo\\" /></li></ul></div>",
+  "actual": "Element tree for <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
 }
 `;
 
 exports[`toContainMatchingElement provides contextual information for the message 3`] = `
 Object {
-  "actual": "HTML Output of <div>:
- <div><ul><li><User index={1} className=\\"userOne\\" /></li><li><User index={2} className=\\"userTwo\\" /></li></ul></div>",
+  "actual": "Element tree for <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
 }
 `;
 
 exports[`toContainMatchingElement provides contextual information for the message 4`] = `
 Object {
-  "actual": "HTML Output of <ul>:
- <ul><li><User index={1} className=\\"userOne\\" /></li><li><User index={2} className=\\"userTwo\\" /></li></ul>",
+  "actual": "Element tree for <ul>:
+ <ul>
+  <li>
+    <User index={1} className=\\"userOne\\" />
+  </li>
+  <li>
+    <User index={2} className=\\"userTwo\\" />
+  </li>
+</ul>",
 }
 `;
 

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainMatchingElements.test.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainMatchingElements.test.js.snap
@@ -2,35 +2,69 @@
 
 exports[`toContainMatchingElements provides contextual information for the message 1`] = `
 Object {
-  "actual": "HTML Output of <div>:
- <div><ul><li><User index={1} className=\\"userOne\\" /></li><li><User index={2} className=\\"userTwo\\" /></li></ul></div>",
+  "actual": "Element tree for <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
 }
 `;
 
 exports[`toContainMatchingElements provides contextual information for the message 2`] = `
 Object {
-  "actual": "HTML Output of <div>:
- <div><ul><li><User index={1} className=\\"userOne\\" /></li><li><User index={2} className=\\"userTwo\\" /></li></ul></div>",
+  "actual": "Element tree for <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
 }
 `;
 
 exports[`toContainMatchingElements provides contextual information for the message 3`] = `
 Object {
-  "actual": "HTML Output of <div>:
- <div><ul><li><User index={1} className=\\"userOne\\" /></li><li><User index={2} className=\\"userTwo\\" /></li></ul></div>",
+  "actual": "Element tree for <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
 }
 `;
 
 exports[`toContainMatchingElements provides contextual information for the message 4`] = `
 Object {
-  "actual": "HTML Output of <ul>:
- <ul><li><User index={1} className=\\"userOne\\" /></li><li><User index={2} className=\\"userTwo\\" /></li></ul>",
+  "actual": "Element tree for <ul>:
+ <ul>
+  <li>
+    <User index={1} className=\\"userOne\\" />
+  </li>
+  <li>
+    <User index={2} className=\\"userTwo\\" />
+  </li>
+</ul>",
 }
 `;
 
 exports[`toContainMatchingElements provides contextual information for the message 5`] = `
 Object {
-  "actual": "HTML Output of <2 (anonymous) nodes found>:
+  "actual": "Element tree for <2 (anonymous) nodes found>:
  Multiple nodes found:
 0: <function User(props) {
   return React.createElement(\\"span\\", {

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainReact.test.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainReact.test.js.snap
@@ -3,10 +3,29 @@
 exports[`toContainReact provides contextual information for the message 1`] = `
 Object {
   "actual": "HTML Output of <div>:
- <div><ul><li><User index={1} /></li><li><User index={2} /></li></ul></div>",
+ <div>
+  <ul>
+    <li>
+      <User index={1} />
+    </li>
+    <li>
+      <User index={2} />
+    </li>
+  </ul>
+</div>",
 }
 `;
 
-exports[`toContainReact returns the message with the proper fail verbage 1`] = `"Expected <div> not to contain <span>User 1</span> but it does."`;
+exports[`toContainReact returns the message with the proper fail verbage 1`] = `
+"Expected <div> not to contain <span>
+  User 
+  1
+</span> but it does."
+`;
 
-exports[`toContainReact returns the message with the proper pass verbage 1`] = `"Expected <div> to contain <span>User 1</span> but it was not found."`;
+exports[`toContainReact returns the message with the proper pass verbage 1`] = `
+"Expected <div> to contain <span>
+  User 
+  1
+</span> but it was not found."
+`;

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toHaveClassName.test.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toHaveClassName.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`toHaveClassName mount provides contextual information for the message (mount) 1`] = `
 Object {
-  "actual": "Found node output: <span class=\\"bar baz\\"></span>",
+  "actual": "Found node output: <span className=\\"bar baz\\" />",
 }
 `;
 

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toHaveDisplayName.test.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toHaveDisplayName.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`toHaveDisplayName mount provides contextual information for the message (mount) 1`] = `
 Object {
-  "actual": "<a id=\\"a\\"></a>",
+  "actual": "<a id=\\"a\\" />",
 }
 `;
 
@@ -22,7 +22,13 @@ exports[`toHaveDisplayName mount returns the message with the proper pass verbag
 exports[`toHaveDisplayName mount works on composite functions 1`] = `
 Object {
   "contextualInformation": Object {
-    "actual": "<div><span id=\\"span\\"></span><span></span><a id=\\"a\\"></a></div>",
+    "actual": "<Fixture>
+  <div>
+    <span id=\\"span\\" />
+    <span />
+    <a id=\\"a\\" />
+  </div>
+</Fixture>",
   },
   "message": "Expected <Fixture> to have display name \\"Fixture\\" but it had display name \\"Fixture\\".",
   "negatedMessage": "Expected <Fixture> to not have display name \\"Fixture\\" but it did.",
@@ -33,7 +39,13 @@ Object {
 exports[`toHaveDisplayName mount works on composite functions 2`] = `
 Object {
   "contextualInformation": Object {
-    "actual": "<div><span id=\\"span\\"></span><span></span><a id=\\"a\\"></a></div>",
+    "actual": "<Fixture>
+  <div>
+    <span id=\\"span\\" />
+    <span />
+    <a id=\\"a\\" />
+  </div>
+</Fixture>",
   },
   "message": "Expected <Fixture> to have display name \\"a\\" but it had display name \\"Fixture\\".",
   "negatedMessage": "Expected <Fixture> to not have display name \\"a\\" but it did.",
@@ -63,7 +75,11 @@ exports[`toHaveDisplayName shallow returns the message with the proper pass verb
 exports[`toHaveDisplayName shallow works on composite functions 1`] = `
 Object {
   "contextualInformation": Object {
-    "actual": "<div><span id=\\"span\\" /><span /><a id=\\"a\\" /></div>",
+    "actual": "<div>
+  <span id=\\"span\\" />
+  <span />
+  <a id=\\"a\\" />
+</div>",
   },
   "message": "Expected <div> to have display name \\"Fixture\\" but it had display name \\"div\\".",
   "negatedMessage": "Expected <div> to not have display name \\"Fixture\\" but it did.",
@@ -74,7 +90,11 @@ Object {
 exports[`toHaveDisplayName shallow works on composite functions 2`] = `
 Object {
   "contextualInformation": Object {
-    "actual": "<div><span id=\\"span\\" /><span /><a id=\\"a\\" /></div>",
+    "actual": "<div>
+  <span id=\\"span\\" />
+  <span />
+  <a id=\\"a\\" />
+</div>",
   },
   "message": "Expected <div> to have display name \\"a\\" but it had display name \\"div\\".",
   "negatedMessage": "Expected <div> to not have display name \\"a\\" but it did.",

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toHaveStyle.test.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toHaveStyle.test.js.snap
@@ -10,7 +10,7 @@ Object {
 exports[`toHaveStyle mount provides the right info for if there is no style prop 1`] = `
 Object {
   "contextualInformation": Object {
-    "actual": "<div></div>",
+    "actual": "<div />",
   },
   "message": "Expected <div> component to have a style prop but it did not.",
   "negatedMessage": "Expected <div> component not to have a style prop but it did.",
@@ -21,7 +21,7 @@ Object {
 exports[`toHaveStyle mount provides the right info when a specific key doesn't exist 1`] = `
 Object {
   "contextualInformation": Object {
-    "actual": "<div style=\\"width: 0px;\\"></div>",
+    "actual": "<div style={{...}} />",
   },
   "message": "Expected <div> component to have a style keys of \\"height\\" but it did not.",
   "negatedMessage": "Expected <div> component not to have a style key of \\"height\\" but it did.",

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toHaveValue.test.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toHaveValue.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`toHaveValue mount provides contextual information for the message (mount) 1`] = `
 Object {
-  "actual": "<input value=\\"test\\">",
+  "actual": "<input defaultValue=\\"test\\" />",
 }
 `;
 

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toMatchSelector.test.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toMatchSelector.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`toMatchSelector mount provides contextual information for the message (mount) 1`] = `
 Object {
-  "actual": "<span id=\\"child\\" class=\\"foo\\"></span>",
+  "actual": "<span id=\\"child\\" className=\\"foo\\" />",
 }
 `;
 

--- a/packages/enzyme-matchers/src/assertions/toContainMatchingElement.js
+++ b/packages/enzyme-matchers/src/assertions/toContainMatchingElement.js
@@ -28,7 +28,7 @@ function toContainMatchingElement(
       `Expected <${nodeName}> to not contain an element matching ` +
       `"${getDisplayName(selector)}" but it did.`,
     contextualInformation: {
-      actual: `HTML Output of <${nodeName}>:\n ${html(enzymeWrapper)}`,
+      actual: `Element tree for <${nodeName}>:\n ${html(enzymeWrapper)}`,
     },
   };
 }

--- a/packages/enzyme-matchers/src/assertions/toContainMatchingElements.js
+++ b/packages/enzyme-matchers/src/assertions/toContainMatchingElements.js
@@ -34,7 +34,7 @@ function toContainMatchingElements(
       ? ''
       : 's'} matching "${getDisplayName(selector)}" but it did.`,
     contextualInformation: {
-      actual: `HTML Output of <${nodeName}>:\n ${html(enzymeWrapper)}`,
+      actual: `Element tree for <${nodeName}>:\n ${html(enzymeWrapper)}`,
     },
   };
 }

--- a/packages/enzyme-matchers/src/utils/__tests__/html.test.js
+++ b/packages/enzyme-matchers/src/utils/__tests__/html.test.js
@@ -3,7 +3,7 @@ const html = require('../html');
 describe('html', () => {
   const inputStrings = {
     shallow: '<input />',
-    mount: '<input>',
+    mount: '<input />',
   };
 
   [shallow, mount].forEach(builder => {
@@ -53,7 +53,7 @@ describe('html', () => {
       const wrapper = shallow(<Bar />);
       // simulate platforms where function.name is undefined
       wrapper.constructor = { toString: () => 'function ShallowWrapper() {}' };
-      expect(html(wrapper)).toBe('<div><Foo /></div>');
+      expect(html(wrapper)).toBe('<div>\n  <Foo />\n</div>');
     });
   });
 });

--- a/packages/enzyme-matchers/src/utils/html.js
+++ b/packages/enzyme-matchers/src/utils/html.js
@@ -39,19 +39,22 @@ function mapWrappersHTML(wrapper: EnzymeObject): Array<string> {
   });
 }
 
-export default function printHTMLForWrapper(wrapper: EnzymeObject): string {
+export default function printHTMLForWrapper(
+  wrapper: EnzymeObject,
+  hostNodesOnly?: boolean
+): string {
   switch (wrapper.getElements().length) {
     case 0: {
       return '[empty set]';
     }
     case 1: {
       if (isShallowWrapper(wrapper)) {
-        // This is used to clean up in any awkward spacing in the debug output.
-        // <div>  <Foo /></div> => <div><Foo /></div>
-        return wrapper.debug().replace(/\n(\s*)/g, '');
+        return wrapper.debug();
       }
-
-      return wrapper.html();
+      if (hostNodesOnly) {
+        return wrapper.html();
+      }
+      return wrapper.debug();
     }
     default: {
       const nodes = mapWrappersHTML(wrapper).reduce(


### PR DESCRIPTION
At some point in Enzyme v2 a change was made to `wrapper.find` to return matches for both host (aka DOM) nodes as well as custom components.

Take for example this code.

```js
const User = props => <span className={props.className}>User {props.index}</span>;

const UserList = () => (
  <ul>
    <li>
      <User index={1} className="userOne" />
    </li>
    <li>
      <User index={2} className="userTwo" />
    </li>
  </ul>
);

const wrapper = mount(<Fixture />); // mount/render/shallow when applicable

expect(wrapper).toContainExactlyOneMatchingElement('.userOne');
```

The above assertion would fail because `wrapper.find('.userOne')` returns two matches, `User.userOne` and `span.userOne`.  This is fine, and can be worked around by qualifying the query with a tag name like `span.userOne`. The problem is that currently, `toContainExactlyOneMatchingElement` prints only HTML output, and if you only see the HTML output, it seems like the assertion should not fail.

This change updates the `html` function to print the full element tree using `wrapper.debug()`, ensuring it's clear why the assertion failed.

I have a follow-on change to add specialized matchers that will only match against host nodes, which is why I added the `hostNodesOnly` argument to the `html` function.