### PR TITLE
Host node matchers

### DIFF
--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toBeEmptyRender.test.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toBeEmptyRender.test.js.snap
@@ -2,7 +2,11 @@
 
 exports[`toBeEmptyRender provides contextual information for the message 1`] = `
 Object {
-  "actual": "Found Nodes HTML output: <div></div>",
+  "actual": "Found Nodes HTML output: <NonEmptyRenderFixture>
+  <div>
+    <EmptyRenderFixture />
+  </div>
+</NonEmptyRenderFixture>",
 }
 `;
 

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainExactlyOneMatchingElement.test.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainExactlyOneMatchingElement.test.js.snap
@@ -1,6 +1,260 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`toContainExactlyOneMatchingElement provides contextual information for the message 1`] = `
+exports[`toContainExactlyOneMatchingElement with a mount wrapper provides contextual information for the message 1`] = `
+Object {
+  "actual": "Element tree for <Fixture>:
+ <Fixture>
+  <div>
+    <ul>
+      <li>
+        <User index={1} className=\\"userOne\\">
+          <span>
+            User 
+            <span data-index=\\"value-1\\">
+              1
+            </span>
+          </span>
+        </User>
+      </li>
+      <li>
+        <User index={2} className=\\"userTwo\\">
+          <span>
+            User 
+            <span data-index=\\"value-2\\">
+              2
+            </span>
+          </span>
+        </User>
+      </li>
+    </ul>
+  </div>
+</Fixture>",
+}
+`;
+
+exports[`toContainExactlyOneMatchingElement with a mount wrapper provides contextual information for the message 2`] = `
+Object {
+  "actual": "Element tree for <Fixture>:
+ <Fixture>
+  <div>
+    <ul>
+      <li>
+        <User index={1} className=\\"userOne\\">
+          <span>
+            User 
+            <span data-index=\\"value-1\\">
+              1
+            </span>
+          </span>
+        </User>
+      </li>
+      <li>
+        <User index={2} className=\\"userTwo\\">
+          <span>
+            User 
+            <span data-index=\\"value-2\\">
+              2
+            </span>
+          </span>
+        </User>
+      </li>
+    </ul>
+  </div>
+</Fixture>",
+}
+`;
+
+exports[`toContainExactlyOneMatchingElement with a mount wrapper provides contextual information for the message 3`] = `
+Object {
+  "actual": "Element tree for <Fixture>:
+ <Fixture>
+  <div>
+    <ul>
+      <li>
+        <User index={1} className=\\"userOne\\">
+          <span>
+            User 
+            <span data-index=\\"value-1\\">
+              1
+            </span>
+          </span>
+        </User>
+      </li>
+      <li>
+        <User index={2} className=\\"userTwo\\">
+          <span>
+            User 
+            <span data-index=\\"value-2\\">
+              2
+            </span>
+          </span>
+        </User>
+      </li>
+    </ul>
+  </div>
+</Fixture>",
+}
+`;
+
+exports[`toContainExactlyOneMatchingElement with a mount wrapper provides contextual information for the message 4`] = `
+Object {
+  "actual": "Element tree for <Fixture>:
+ <Fixture>
+  <div>
+    <ul>
+      <li>
+        <User index={1} className=\\"userOne\\">
+          <span>
+            User 
+            <span data-index=\\"value-1\\">
+              1
+            </span>
+          </span>
+        </User>
+      </li>
+      <li>
+        <User index={2} className=\\"userTwo\\">
+          <span>
+            User 
+            <span data-index=\\"value-2\\">
+              2
+            </span>
+          </span>
+        </User>
+      </li>
+    </ul>
+  </div>
+</Fixture>",
+}
+`;
+
+exports[`toContainExactlyOneMatchingElement with a mount wrapper provides contextual information for the message 5`] = `
+Object {
+  "actual": "Element tree for <ul>:
+ <ul>
+  <li>
+    <User index={1} className=\\"userOne\\">
+      <span>
+        User 
+        <span data-index=\\"value-1\\">
+          1
+        </span>
+      </span>
+    </User>
+  </li>
+  <li>
+    <User index={2} className=\\"userTwo\\">
+      <span>
+        User 
+        <span data-index=\\"value-2\\">
+          2
+        </span>
+      </span>
+    </User>
+  </li>
+</ul>",
+}
+`;
+
+exports[`toContainExactlyOneMatchingElement with a mount wrapper provides contextual information for the message 6`] = `
+Object {
+  "actual": "Element tree for <2 (anonymous) nodes found>:
+ Multiple nodes found:
+0: <function User(props) {
+  return React.createElement(\\"span\\", null, \\"User \\", React.createElement(\\"span\\", {
+    \\"data-index\\": \`value-\${props.index}\`
+  }, props.index));
+} index=\\"1\\" className=\\"userOne\\"/>
+1: <function User(props) {
+  return React.createElement(\\"span\\", null, \\"User \\", React.createElement(\\"span\\", {
+    \\"data-index\\": \`value-\${props.index}\`
+  }, props.index));
+} index=\\"2\\" className=\\"userTwo\\"/>
+",
+}
+`;
+
+exports[`toContainExactlyOneMatchingElement with a mount wrapper provides contextual information for the message 7`] = `
+Object {
+  "actual": "Element tree for <Fixture>:
+ <Fixture>
+  <div>
+    <ul>
+      <li>
+        <User index={1} className=\\"userOne\\">
+          <span>
+            User 
+            <span data-index=\\"value-1\\">
+              1
+            </span>
+          </span>
+        </User>
+      </li>
+      <li>
+        <User index={2} className=\\"userTwo\\">
+          <span>
+            User 
+            <span data-index=\\"value-2\\">
+              2
+            </span>
+          </span>
+        </User>
+      </li>
+    </ul>
+  </div>
+</Fixture>",
+}
+`;
+
+exports[`toContainExactlyOneMatchingElement with a mount wrapper provides contextual information for the message 8`] = `
+Object {
+  "actual": "Element tree for <Fixture>:
+ <Fixture>
+  <div>
+    <ul>
+      <li>
+        <User index={1} className=\\"userOne\\">
+          <span>
+            User 
+            <span data-index=\\"value-1\\">
+              1
+            </span>
+          </span>
+        </User>
+      </li>
+      <li>
+        <User index={2} className=\\"userTwo\\">
+          <span>
+            User 
+            <span data-index=\\"value-2\\">
+              2
+            </span>
+          </span>
+        </User>
+      </li>
+    </ul>
+  </div>
+</Fixture>",
+}
+`;
+
+exports[`toContainExactlyOneMatchingElement with a mount wrapper returns the proper verbage for ".userOne" 1`] = `"Expected <Fixture> to contain 1 element matching \\".userOne\\" but 1 was found."`;
+
+exports[`toContainExactlyOneMatchingElement with a mount wrapper returns the proper verbage for ".userThree" 1`] = `"Expected <Fixture> to not contain 1 element matching \\".userThree\\" but it did."`;
+
+exports[`toContainExactlyOneMatchingElement with a mount wrapper returns the proper verbage for "[data-index="value-1"]" 1`] = `"Expected <Fixture> to contain 1 element matching \\"[data-index=\\"value-1\\"]\\" but 1 was found."`;
+
+exports[`toContainExactlyOneMatchingElement with a mount wrapper returns the proper verbage for "[index=1]" 1`] = `"Expected <Fixture> to contain 1 element matching \\"[index=1]\\" but 1 was found."`;
+
+exports[`toContainExactlyOneMatchingElement with a mount wrapper returns the proper verbage for "[index=1]" 2`] = `"Expected <2 (anonymous) nodes found> to contain 1 element matching \\"[index=1]\\" but 1 was found."`;
+
+exports[`toContainExactlyOneMatchingElement with a mount wrapper returns the proper verbage for "[index]" 1`] = `"Expected <Fixture> to not contain 1 element matching \\"[index]\\" but it did."`;
+
+exports[`toContainExactlyOneMatchingElement with a mount wrapper returns the proper verbage for "[index]" 2`] = `"Expected <ul> to not contain 1 element matching \\"[index]\\" but it did."`;
+
+exports[`toContainExactlyOneMatchingElement with a mount wrapper returns the proper verbage for "User" 1`] = `"Expected <Fixture> to not contain 1 element matching \\"User\\" but it did."`;
+
+exports[`toContainExactlyOneMatchingElement with a shallow wrapper provides contextual information for the message 1`] = `
 Object {
   "actual": "Element tree for <div>:
  <div>
@@ -16,7 +270,7 @@ Object {
 }
 `;
 
-exports[`toContainExactlyOneMatchingElement provides contextual information for the message 2`] = `
+exports[`toContainExactlyOneMatchingElement with a shallow wrapper provides contextual information for the message 2`] = `
 Object {
   "actual": "Element tree for <div>:
  <div>
@@ -32,7 +286,39 @@ Object {
 }
 `;
 
-exports[`toContainExactlyOneMatchingElement provides contextual information for the message 3`] = `
+exports[`toContainExactlyOneMatchingElement with a shallow wrapper provides contextual information for the message 3`] = `
+Object {
+  "actual": "Element tree for <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
+}
+`;
+
+exports[`toContainExactlyOneMatchingElement with a shallow wrapper provides contextual information for the message 4`] = `
+Object {
+  "actual": "Element tree for <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
+}
+`;
+
+exports[`toContainExactlyOneMatchingElement with a shallow wrapper provides contextual information for the message 5`] = `
 Object {
   "actual": "Element tree for <ul>:
  <ul>
@@ -46,16 +332,68 @@ Object {
 }
 `;
 
-exports[`toContainExactlyOneMatchingElement returns the message with the proper fail verbage 1`] = `"Expected <div> to not contain 1 element matching \\"User\\" but it did."`;
+exports[`toContainExactlyOneMatchingElement with a shallow wrapper provides contextual information for the message 6`] = `
+Object {
+  "actual": "Element tree for <2 (anonymous) nodes found>:
+ Multiple nodes found:
+0: <function User(props) {
+  return React.createElement(\\"span\\", null, \\"User \\", React.createElement(\\"span\\", {
+    \\"data-index\\": \`value-\${props.index}\`
+  }, props.index));
+} index=\\"1\\" className=\\"userOne\\"/>
+1: <function User(props) {
+  return React.createElement(\\"span\\", null, \\"User \\", React.createElement(\\"span\\", {
+    \\"data-index\\": \`value-\${props.index}\`
+  }, props.index));
+} index=\\"2\\" className=\\"userTwo\\"/>
+",
+}
+`;
 
-exports[`toContainExactlyOneMatchingElement returns the message with the proper fail verbage 2`] = `"Expected <div> to not contain 1 element matching \\".userThree\\" but it did."`;
+exports[`toContainExactlyOneMatchingElement with a shallow wrapper provides contextual information for the message 7`] = `
+Object {
+  "actual": "Element tree for <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
+}
+`;
 
-exports[`toContainExactlyOneMatchingElement returns the message with the proper fail verbage 3`] = `"Expected <div> to not contain 1 element matching \\"[index]\\" but it did."`;
+exports[`toContainExactlyOneMatchingElement with a shallow wrapper provides contextual information for the message 8`] = `
+Object {
+  "actual": "Element tree for <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
+}
+`;
 
-exports[`toContainExactlyOneMatchingElement returns the message with the proper fail verbage 4`] = `"Expected <ul> to not contain 1 element matching \\"[index]\\" but it did."`;
+exports[`toContainExactlyOneMatchingElement with a shallow wrapper returns the proper verbage for ".userOne" 1`] = `"Expected <div> to contain 1 element matching \\".userOne\\" but 1 was found."`;
 
-exports[`toContainExactlyOneMatchingElement returns the message with the proper pass verbage 1`] = `"Expected <div> to contain 1 element matching \\".userOne\\" but 1 was found."`;
+exports[`toContainExactlyOneMatchingElement with a shallow wrapper returns the proper verbage for ".userThree" 1`] = `"Expected <div> to not contain 1 element matching \\".userThree\\" but it did."`;
 
-exports[`toContainExactlyOneMatchingElement returns the message with the proper pass verbage 2`] = `"Expected <div> to contain 1 element matching \\"[index=1]\\" but 1 was found."`;
+exports[`toContainExactlyOneMatchingElement with a shallow wrapper returns the proper verbage for "[data-index="value-1"]" 1`] = `"Expected <div> to not contain 1 element matching \\"[data-index=\\"value-1\\"]\\" but it did."`;
 
-exports[`toContainExactlyOneMatchingElement returns the message with the proper pass verbage 3`] = `"Expected <ul> to contain 1 element matching \\"[index=1]\\" but 1 was found."`;
+exports[`toContainExactlyOneMatchingElement with a shallow wrapper returns the proper verbage for "[index=1]" 1`] = `"Expected <div> to contain 1 element matching \\"[index=1]\\" but 1 was found."`;
+
+exports[`toContainExactlyOneMatchingElement with a shallow wrapper returns the proper verbage for "[index=1]" 2`] = `"Expected <2 (anonymous) nodes found> to contain 1 element matching \\"[index=1]\\" but 1 was found."`;
+
+exports[`toContainExactlyOneMatchingElement with a shallow wrapper returns the proper verbage for "[index]" 1`] = `"Expected <div> to not contain 1 element matching \\"[index]\\" but it did."`;
+
+exports[`toContainExactlyOneMatchingElement with a shallow wrapper returns the proper verbage for "[index]" 2`] = `"Expected <ul> to not contain 1 element matching \\"[index]\\" but it did."`;
+
+exports[`toContainExactlyOneMatchingElement with a shallow wrapper returns the proper verbage for "User" 1`] = `"Expected <div> to not contain 1 element matching \\"User\\" but it did."`;

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainExactlyOneMatchingElement.test.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainExactlyOneMatchingElement.test.js.snap
@@ -2,22 +2,47 @@
 
 exports[`toContainExactlyOneMatchingElement provides contextual information for the message 1`] = `
 Object {
-  "actual": "HTML Output of <div>:
- <div><ul><li><User index={1} className=\\"userOne\\" /></li><li><User index={2} className=\\"userTwo\\" /></li></ul></div>",
+  "actual": "Element tree for <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
 }
 `;
 
 exports[`toContainExactlyOneMatchingElement provides contextual information for the message 2`] = `
 Object {
-  "actual": "HTML Output of <div>:
- <div><ul><li><User index={1} className=\\"userOne\\" /></li><li><User index={2} className=\\"userTwo\\" /></li></ul></div>",
+  "actual": "Element tree for <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
 }
 `;
 
 exports[`toContainExactlyOneMatchingElement provides contextual information for the message 3`] = `
 Object {
-  "actual": "HTML Output of <ul>:
- <ul><li><User index={1} className=\\"userOne\\" /></li><li><User index={2} className=\\"userTwo\\" /></li></ul>",
+  "actual": "Element tree for <ul>:
+ <ul>
+  <li>
+    <User index={1} className=\\"userOne\\" />
+  </li>
+  <li>
+    <User index={2} className=\\"userTwo\\" />
+  </li>
+</ul>",
 }
 `;
 

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainExactlyOneMatchingNode.test.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainExactlyOneMatchingNode.test.js.snap
@@ -1,0 +1,212 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`toContainExactlyOneMatchingNode with a mount wrapper provides contextual information for the message 1`] = `
+Object {
+  "actual": "HTML Output of <Fixture>:
+ <div><ul><li><span class=\\"userOne\\">User <span data-index=\\"value-1\\">1</span></span></li><li><span class=\\"userTwo\\">User <span data-index=\\"value-2\\">2</span></span></li></ul></div>",
+}
+`;
+
+exports[`toContainExactlyOneMatchingNode with a mount wrapper provides contextual information for the message 2`] = `
+Object {
+  "actual": "HTML Output of <Fixture>:
+ <div><ul><li><span class=\\"userOne\\">User <span data-index=\\"value-1\\">1</span></span></li><li><span class=\\"userTwo\\">User <span data-index=\\"value-2\\">2</span></span></li></ul></div>",
+}
+`;
+
+exports[`toContainExactlyOneMatchingNode with a mount wrapper provides contextual information for the message 3`] = `
+Object {
+  "actual": "HTML Output of <Fixture>:
+ <div><ul><li><span class=\\"userOne\\">User <span data-index=\\"value-1\\">1</span></span></li><li><span class=\\"userTwo\\">User <span data-index=\\"value-2\\">2</span></span></li></ul></div>",
+}
+`;
+
+exports[`toContainExactlyOneMatchingNode with a mount wrapper provides contextual information for the message 4`] = `
+Object {
+  "actual": "HTML Output of <2 (anonymous) nodes found>:
+ Multiple nodes found:
+0: <function User(props) {
+  return React.createElement(\\"span\\", {
+    className: props.className
+  }, \\"User \\", React.createElement(\\"span\\", {
+    \\"data-index\\": \`value-\${props.index}\`
+  }, props.index));
+} index=\\"1\\" className=\\"userOne\\"/>
+1: <function User(props) {
+  return React.createElement(\\"span\\", {
+    className: props.className
+  }, \\"User \\", React.createElement(\\"span\\", {
+    \\"data-index\\": \`value-\${props.index}\`
+  }, props.index));
+} index=\\"2\\" className=\\"userTwo\\"/>
+",
+}
+`;
+
+exports[`toContainExactlyOneMatchingNode with a mount wrapper provides contextual information for the message 5`] = `
+Object {
+  "actual": "HTML Output of <2 (anonymous) nodes found>:
+ Multiple nodes found:
+0: <function User(props) {
+  return React.createElement(\\"span\\", {
+    className: props.className
+  }, \\"User \\", React.createElement(\\"span\\", {
+    \\"data-index\\": \`value-\${props.index}\`
+  }, props.index));
+} index=\\"1\\" className=\\"userOne\\"/>
+1: <function User(props) {
+  return React.createElement(\\"span\\", {
+    className: props.className
+  }, \\"User \\", React.createElement(\\"span\\", {
+    \\"data-index\\": \`value-\${props.index}\`
+  }, props.index));
+} index=\\"2\\" className=\\"userTwo\\"/>
+",
+}
+`;
+
+exports[`toContainExactlyOneMatchingNode with a mount wrapper provides contextual information for the message 6`] = `
+Object {
+  "actual": "HTML Output of <Fixture>:
+ <div><ul><li><span class=\\"userOne\\">User <span data-index=\\"value-1\\">1</span></span></li><li><span class=\\"userTwo\\">User <span data-index=\\"value-2\\">2</span></span></li></ul></div>",
+}
+`;
+
+exports[`toContainExactlyOneMatchingNode with a mount wrapper provides contextual information for the message 7`] = `
+Object {
+  "actual": "HTML Output of <Fixture>:
+ <div><ul><li><span class=\\"userOne\\">User <span data-index=\\"value-1\\">1</span></span></li><li><span class=\\"userTwo\\">User <span data-index=\\"value-2\\">2</span></span></li></ul></div>",
+}
+`;
+
+exports[`toContainExactlyOneMatchingNode with a mount wrapper returns the proper verbage for ".userOne" 1`] = `"Expected <Fixture> to contain 1 node matching \\".userOne\\" but 1 was found."`;
+
+exports[`toContainExactlyOneMatchingNode with a mount wrapper returns the proper verbage for ".userOne" 2`] = `"Expected <2 (anonymous) nodes found> to contain 1 node matching \\".userOne\\" but 1 was found."`;
+
+exports[`toContainExactlyOneMatchingNode with a mount wrapper returns the proper verbage for ".userThree" 1`] = `"Expected <Fixture> to not contain 1 node matching \\".userThree\\" but it did."`;
+
+exports[`toContainExactlyOneMatchingNode with a mount wrapper returns the proper verbage for "[data-index="value-1"]" 1`] = `"Expected <Fixture> to contain 1 node matching \\"[data-index=\\"value-1\\"]\\" but 1 was found."`;
+
+exports[`toContainExactlyOneMatchingNode with a mount wrapper returns the proper verbage for "[data-index="value-1"]" 2`] = `"Expected <2 (anonymous) nodes found> to contain 1 node matching \\"[data-index=\\"value-1\\"]\\" but 1 was found."`;
+
+exports[`toContainExactlyOneMatchingNode with a mount wrapper returns the proper verbage for "[data-index]" 1`] = `"Expected <Fixture> to not contain 1 node matching \\"[data-index]\\" but it did."`;
+
+exports[`toContainExactlyOneMatchingNode with a mount wrapper returns the proper verbage for "[data-index]" 2`] = `"Expected <Fixture> to not contain 1 node matching \\"[data-index]\\" but it did."`;
+
+exports[`toContainExactlyOneMatchingNode with a shallow wrapper provides contextual information for the message 1`] = `
+Object {
+  "actual": "HTML Output of <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
+}
+`;
+
+exports[`toContainExactlyOneMatchingNode with a shallow wrapper provides contextual information for the message 2`] = `
+Object {
+  "actual": "HTML Output of <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
+}
+`;
+
+exports[`toContainExactlyOneMatchingNode with a shallow wrapper provides contextual information for the message 3`] = `
+Object {
+  "actual": "HTML Output of <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
+}
+`;
+
+exports[`toContainExactlyOneMatchingNode with a shallow wrapper provides contextual information for the message 4`] = `
+Object {
+  "actual": "HTML Output of <span>:
+ <span className=\\"userOne\\">
+  User 
+  <span data-index=\\"value-1\\">
+    1
+  </span>
+</span>",
+}
+`;
+
+exports[`toContainExactlyOneMatchingNode with a shallow wrapper provides contextual information for the message 5`] = `
+Object {
+  "actual": "HTML Output of <span>:
+ <span className=\\"userOne\\">
+  User 
+  <span data-index=\\"value-1\\">
+    1
+  </span>
+</span>",
+}
+`;
+
+exports[`toContainExactlyOneMatchingNode with a shallow wrapper provides contextual information for the message 6`] = `
+Object {
+  "actual": "HTML Output of <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
+}
+`;
+
+exports[`toContainExactlyOneMatchingNode with a shallow wrapper provides contextual information for the message 7`] = `
+Object {
+  "actual": "HTML Output of <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
+}
+`;
+
+exports[`toContainExactlyOneMatchingNode with a shallow wrapper returns the proper verbage for ".userOne" 1`] = `"Expected <div> to not contain 1 node matching \\".userOne\\" but it did."`;
+
+exports[`toContainExactlyOneMatchingNode with a shallow wrapper returns the proper verbage for ".userOne" 2`] = `"Expected <span> to contain 1 node matching \\".userOne\\" but 1 was found."`;
+
+exports[`toContainExactlyOneMatchingNode with a shallow wrapper returns the proper verbage for ".userThree" 1`] = `"Expected <div> to not contain 1 node matching \\".userThree\\" but it did."`;
+
+exports[`toContainExactlyOneMatchingNode with a shallow wrapper returns the proper verbage for "[data-index="value-1"]" 1`] = `"Expected <div> to not contain 1 node matching \\"[data-index=\\"value-1\\"]\\" but it did."`;
+
+exports[`toContainExactlyOneMatchingNode with a shallow wrapper returns the proper verbage for "[data-index="value-1"]" 2`] = `"Expected <span> to contain 1 node matching \\"[data-index=\\"value-1\\"]\\" but 1 was found."`;
+
+exports[`toContainExactlyOneMatchingNode with a shallow wrapper returns the proper verbage for "[data-index]" 1`] = `"Expected <div> to not contain 1 node matching \\"[data-index]\\" but it did."`;
+
+exports[`toContainExactlyOneMatchingNode with a shallow wrapper returns the proper verbage for "[data-index]" 2`] = `"Expected <div> to not contain 1 node matching \\"[data-index]\\" but it did."`;

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainMatchingElement.test.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainMatchingElement.test.js.snap
@@ -1,6 +1,298 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`toContainMatchingElement provides contextual information for the message 1`] = `
+exports[`toContainMatchingElement with a mount wrapper provides contextual information for the message 1`] = `
+Object {
+  "actual": "Element tree for <Fixture>:
+ <Fixture>
+  <div>
+    <ul>
+      <li>
+        <User index={1} className=\\"userOne\\">
+          <span className=\\"userOne\\">
+            User 
+            <span data-index=\\"value-1\\">
+              1
+            </span>
+          </span>
+        </User>
+      </li>
+      <li>
+        <User index={2} className=\\"userTwo\\">
+          <span className=\\"userTwo\\">
+            User 
+            <span data-index=\\"value-2\\">
+              2
+            </span>
+          </span>
+        </User>
+      </li>
+    </ul>
+  </div>
+</Fixture>",
+}
+`;
+
+exports[`toContainMatchingElement with a mount wrapper provides contextual information for the message 2`] = `
+Object {
+  "actual": "Element tree for <Fixture>:
+ <Fixture>
+  <div>
+    <ul>
+      <li>
+        <User index={1} className=\\"userOne\\">
+          <span className=\\"userOne\\">
+            User 
+            <span data-index=\\"value-1\\">
+              1
+            </span>
+          </span>
+        </User>
+      </li>
+      <li>
+        <User index={2} className=\\"userTwo\\">
+          <span className=\\"userTwo\\">
+            User 
+            <span data-index=\\"value-2\\">
+              2
+            </span>
+          </span>
+        </User>
+      </li>
+    </ul>
+  </div>
+</Fixture>",
+}
+`;
+
+exports[`toContainMatchingElement with a mount wrapper provides contextual information for the message 3`] = `
+Object {
+  "actual": "Element tree for <Fixture>:
+ <Fixture>
+  <div>
+    <ul>
+      <li>
+        <User index={1} className=\\"userOne\\">
+          <span className=\\"userOne\\">
+            User 
+            <span data-index=\\"value-1\\">
+              1
+            </span>
+          </span>
+        </User>
+      </li>
+      <li>
+        <User index={2} className=\\"userTwo\\">
+          <span className=\\"userTwo\\">
+            User 
+            <span data-index=\\"value-2\\">
+              2
+            </span>
+          </span>
+        </User>
+      </li>
+    </ul>
+  </div>
+</Fixture>",
+}
+`;
+
+exports[`toContainMatchingElement with a mount wrapper provides contextual information for the message 4`] = `
+Object {
+  "actual": "Element tree for <Fixture>:
+ <Fixture>
+  <div>
+    <ul>
+      <li>
+        <User index={1} className=\\"userOne\\">
+          <span className=\\"userOne\\">
+            User 
+            <span data-index=\\"value-1\\">
+              1
+            </span>
+          </span>
+        </User>
+      </li>
+      <li>
+        <User index={2} className=\\"userTwo\\">
+          <span className=\\"userTwo\\">
+            User 
+            <span data-index=\\"value-2\\">
+              2
+            </span>
+          </span>
+        </User>
+      </li>
+    </ul>
+  </div>
+</Fixture>",
+}
+`;
+
+exports[`toContainMatchingElement with a mount wrapper provides contextual information for the message 5`] = `
+Object {
+  "actual": "Element tree for <ul>:
+ <ul>
+  <li>
+    <User index={1} className=\\"userOne\\">
+      <span className=\\"userOne\\">
+        User 
+        <span data-index=\\"value-1\\">
+          1
+        </span>
+      </span>
+    </User>
+  </li>
+  <li>
+    <User index={2} className=\\"userTwo\\">
+      <span className=\\"userTwo\\">
+        User 
+        <span data-index=\\"value-2\\">
+          2
+        </span>
+      </span>
+    </User>
+  </li>
+</ul>",
+}
+`;
+
+exports[`toContainMatchingElement with a mount wrapper provides contextual information for the message 6`] = `
+Object {
+  "actual": "Element tree for <2 (anonymous) nodes found>:
+ Multiple nodes found:
+0: <function User(props) {
+  return React.createElement(\\"span\\", {
+    className: props.className
+  }, \\"User \\", React.createElement(\\"span\\", {
+    \\"data-index\\": \`value-\${props.index}\`
+  }, props.index));
+} index=\\"1\\" className=\\"userOne\\"/>
+1: <function User(props) {
+  return React.createElement(\\"span\\", {
+    className: props.className
+  }, \\"User \\", React.createElement(\\"span\\", {
+    \\"data-index\\": \`value-\${props.index}\`
+  }, props.index));
+} index=\\"2\\" className=\\"userTwo\\"/>
+",
+}
+`;
+
+exports[`toContainMatchingElement with a mount wrapper provides contextual information for the message 7`] = `
+Object {
+  "actual": "Element tree for <Fixture>:
+ <Fixture>
+  <div>
+    <ul>
+      <li>
+        <User index={1} className=\\"userOne\\">
+          <span className=\\"userOne\\">
+            User 
+            <span data-index=\\"value-1\\">
+              1
+            </span>
+          </span>
+        </User>
+      </li>
+      <li>
+        <User index={2} className=\\"userTwo\\">
+          <span className=\\"userTwo\\">
+            User 
+            <span data-index=\\"value-2\\">
+              2
+            </span>
+          </span>
+        </User>
+      </li>
+    </ul>
+  </div>
+</Fixture>",
+}
+`;
+
+exports[`toContainMatchingElement with a mount wrapper provides contextual information for the message 8`] = `
+Object {
+  "actual": "Element tree for <Fixture>:
+ <Fixture>
+  <div>
+    <ul>
+      <li>
+        <User index={1} className=\\"userOne\\">
+          <span className=\\"userOne\\">
+            User 
+            <span data-index=\\"value-1\\">
+              1
+            </span>
+          </span>
+        </User>
+      </li>
+      <li>
+        <User index={2} className=\\"userTwo\\">
+          <span className=\\"userTwo\\">
+            User 
+            <span data-index=\\"value-2\\">
+              2
+            </span>
+          </span>
+        </User>
+      </li>
+    </ul>
+  </div>
+</Fixture>",
+}
+`;
+
+exports[`toContainMatchingElement with a mount wrapper provides contextual information for the message 9`] = `
+Object {
+  "actual": "Element tree for <Fixture>:
+ <Fixture>
+  <div>
+    <ul>
+      <li>
+        <User index={1} className=\\"userOne\\">
+          <span className=\\"userOne\\">
+            User 
+            <span data-index=\\"value-1\\">
+              1
+            </span>
+          </span>
+        </User>
+      </li>
+      <li>
+        <User index={2} className=\\"userTwo\\">
+          <span className=\\"userTwo\\">
+            User 
+            <span data-index=\\"value-2\\">
+              2
+            </span>
+          </span>
+        </User>
+      </li>
+    </ul>
+  </div>
+</Fixture>",
+}
+`;
+
+exports[`toContainMatchingElement with a mount wrapper returns the proper verbage for ".userOne" 1`] = `"Expected <Fixture> to contain at least one element matching \\".userOne\\" but none were found."`;
+
+exports[`toContainMatchingElement with a mount wrapper returns the proper verbage for ".userThree" 1`] = `"Expected <Fixture> to not contain an element matching \\".userThree\\" but it did."`;
+
+exports[`toContainMatchingElement with a mount wrapper returns the proper verbage for "[data-index="value-1"]" 1`] = `"Expected <Fixture> to contain at least one element matching \\"[data-index=\\"value-1\\"]\\" but none were found."`;
+
+exports[`toContainMatchingElement with a mount wrapper returns the proper verbage for "[data-index]" 1`] = `"Expected <Fixture> to contain at least one element matching \\"[data-index]\\" but none were found."`;
+
+exports[`toContainMatchingElement with a mount wrapper returns the proper verbage for "[index=1]" 1`] = `"Expected <Fixture> to contain at least one element matching \\"[index=1]\\" but none were found."`;
+
+exports[`toContainMatchingElement with a mount wrapper returns the proper verbage for "[index=1]" 2`] = `"Expected <2 (anonymous) nodes found> to contain at least one element matching \\"[index=1]\\" but none were found."`;
+
+exports[`toContainMatchingElement with a mount wrapper returns the proper verbage for "[index]" 1`] = `"Expected <Fixture> to contain at least one element matching \\"[index]\\" but none were found."`;
+
+exports[`toContainMatchingElement with a mount wrapper returns the proper verbage for "[index]" 2`] = `"Expected <ul> to contain at least one element matching \\"[index]\\" but none were found."`;
+
+exports[`toContainMatchingElement with a mount wrapper returns the proper verbage for "User" 1`] = `"Expected <Fixture> to contain at least one element matching \\"User\\" but none were found."`;
+
+exports[`toContainMatchingElement with a shallow wrapper provides contextual information for the message 1`] = `
 Object {
   "actual": "Element tree for <div>:
  <div>
@@ -16,7 +308,7 @@ Object {
 }
 `;
 
-exports[`toContainMatchingElement provides contextual information for the message 2`] = `
+exports[`toContainMatchingElement with a shallow wrapper provides contextual information for the message 2`] = `
 Object {
   "actual": "Element tree for <div>:
  <div>
@@ -32,7 +324,7 @@ Object {
 }
 `;
 
-exports[`toContainMatchingElement provides contextual information for the message 3`] = `
+exports[`toContainMatchingElement with a shallow wrapper provides contextual information for the message 3`] = `
 Object {
   "actual": "Element tree for <div>:
  <div>
@@ -48,7 +340,23 @@ Object {
 }
 `;
 
-exports[`toContainMatchingElement provides contextual information for the message 4`] = `
+exports[`toContainMatchingElement with a shallow wrapper provides contextual information for the message 4`] = `
+Object {
+  "actual": "Element tree for <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
+}
+`;
+
+exports[`toContainMatchingElement with a shallow wrapper provides contextual information for the message 5`] = `
 Object {
   "actual": "Element tree for <ul>:
  <ul>
@@ -62,16 +370,90 @@ Object {
 }
 `;
 
-exports[`toContainMatchingElement returns the message with the proper fail verbage 1`] = `"Expected <div> to not contain an element matching \\"Foo\\" but it did."`;
+exports[`toContainMatchingElement with a shallow wrapper provides contextual information for the message 6`] = `
+Object {
+  "actual": "Element tree for <2 (anonymous) nodes found>:
+ Multiple nodes found:
+0: <function User(props) {
+  return React.createElement(\\"span\\", {
+    className: props.className
+  }, \\"User \\", React.createElement(\\"span\\", {
+    \\"data-index\\": \`value-\${props.index}\`
+  }, props.index));
+} index=\\"1\\" className=\\"userOne\\"/>
+1: <function User(props) {
+  return React.createElement(\\"span\\", {
+    className: props.className
+  }, \\"User \\", React.createElement(\\"span\\", {
+    \\"data-index\\": \`value-\${props.index}\`
+  }, props.index));
+} index=\\"2\\" className=\\"userTwo\\"/>
+",
+}
+`;
 
-exports[`toContainMatchingElement returns the message with the proper fail verbage 2`] = `"Expected <div> to not contain an element matching \\".userThree\\" but it did."`;
+exports[`toContainMatchingElement with a shallow wrapper provides contextual information for the message 7`] = `
+Object {
+  "actual": "Element tree for <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
+}
+`;
 
-exports[`toContainMatchingElement returns the message with the proper fail verbage 3`] = `"Expected <ul> to not contain an element matching \\"Bar\\" but it did."`;
+exports[`toContainMatchingElement with a shallow wrapper provides contextual information for the message 8`] = `
+Object {
+  "actual": "Element tree for <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
+}
+`;
 
-exports[`toContainMatchingElement returns the message with the proper pass verbage 1`] = `"Expected <div> to contain at least one element matching \\"User\\" but none were found."`;
+exports[`toContainMatchingElement with a shallow wrapper provides contextual information for the message 9`] = `
+Object {
+  "actual": "Element tree for <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
+}
+`;
 
-exports[`toContainMatchingElement returns the message with the proper pass verbage 2`] = `"Expected <div> to contain at least one element matching \\"[index=1]\\" but none were found."`;
+exports[`toContainMatchingElement with a shallow wrapper returns the proper verbage for ".userOne" 1`] = `"Expected <div> to contain at least one element matching \\".userOne\\" but none were found."`;
 
-exports[`toContainMatchingElement returns the message with the proper pass verbage 3`] = `"Expected <div> to contain at least one element matching \\"[index]\\" but none were found."`;
+exports[`toContainMatchingElement with a shallow wrapper returns the proper verbage for ".userThree" 1`] = `"Expected <div> to not contain an element matching \\".userThree\\" but it did."`;
 
-exports[`toContainMatchingElement returns the message with the proper pass verbage 4`] = `"Expected <ul> to contain at least one element matching \\"[index]\\" but none were found."`;
+exports[`toContainMatchingElement with a shallow wrapper returns the proper verbage for "[data-index="value-1"]" 1`] = `"Expected <div> to not contain an element matching \\"[data-index=\\"value-1\\"]\\" but it did."`;
+
+exports[`toContainMatchingElement with a shallow wrapper returns the proper verbage for "[data-index]" 1`] = `"Expected <div> to not contain an element matching \\"[data-index]\\" but it did."`;
+
+exports[`toContainMatchingElement with a shallow wrapper returns the proper verbage for "[index=1]" 1`] = `"Expected <div> to contain at least one element matching \\"[index=1]\\" but none were found."`;
+
+exports[`toContainMatchingElement with a shallow wrapper returns the proper verbage for "[index=1]" 2`] = `"Expected <2 (anonymous) nodes found> to contain at least one element matching \\"[index=1]\\" but none were found."`;
+
+exports[`toContainMatchingElement with a shallow wrapper returns the proper verbage for "[index]" 1`] = `"Expected <div> to contain at least one element matching \\"[index]\\" but none were found."`;
+
+exports[`toContainMatchingElement with a shallow wrapper returns the proper verbage for "[index]" 2`] = `"Expected <ul> to contain at least one element matching \\"[index]\\" but none were found."`;
+
+exports[`toContainMatchingElement with a shallow wrapper returns the proper verbage for "User" 1`] = `"Expected <div> to contain at least one element matching \\"User\\" but none were found."`;

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainMatchingElement.test.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainMatchingElement.test.js.snap
@@ -2,29 +2,63 @@
 
 exports[`toContainMatchingElement provides contextual information for the message 1`] = `
 Object {
-  "actual": "HTML Output of <div>:
- <div><ul><li><User index={1} className=\\"userOne\\" /></li><li><User index={2} className=\\"userTwo\\" /></li></ul></div>",
+  "actual": "Element tree for <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
 }
 `;
 
 exports[`toContainMatchingElement provides contextual information for the message 2`] = `
 Object {
-  "actual": "HTML Output of <div>:
- <div><ul><li><User index={1} className=\\"userOne\\" /></li><li><User index={2} className=\\"userTwo\\" /></li></ul></div>",
+  "actual": "Element tree for <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
 }
 `;
 
 exports[`toContainMatchingElement provides contextual information for the message 3`] = `
 Object {
-  "actual": "HTML Output of <div>:
- <div><ul><li><User index={1} className=\\"userOne\\" /></li><li><User index={2} className=\\"userTwo\\" /></li></ul></div>",
+  "actual": "Element tree for <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
 }
 `;
 
 exports[`toContainMatchingElement provides contextual information for the message 4`] = `
 Object {
-  "actual": "HTML Output of <ul>:
- <ul><li><User index={1} className=\\"userOne\\" /></li><li><User index={2} className=\\"userTwo\\" /></li></ul>",
+  "actual": "Element tree for <ul>:
+ <ul>
+  <li>
+    <User index={1} className=\\"userOne\\" />
+  </li>
+  <li>
+    <User index={2} className=\\"userTwo\\" />
+  </li>
+</ul>",
 }
 `;
 

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainMatchingElements.test.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainMatchingElements.test.js.snap
@@ -1,6 +1,430 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`toContainMatchingElements provides contextual information for the message 1`] = `
+exports[`toContainMatchingElements with a mount wrapper provides contextual information for the message 1`] = `
+Object {
+  "actual": "Element tree for <Fixture>:
+ <Fixture>
+  <div>
+    <ul>
+      <li>
+        <User index={1} className=\\"userOne\\">
+          <span className=\\"userOne\\">
+            User 
+            <span data-index=\\"value-1\\">
+              1
+            </span>
+          </span>
+        </User>
+      </li>
+      <li>
+        <User index={2} className=\\"userTwo\\">
+          <span className=\\"userTwo\\">
+            User 
+            <span data-index=\\"value-2\\">
+              2
+            </span>
+          </span>
+        </User>
+      </li>
+    </ul>
+  </div>
+</Fixture>",
+}
+`;
+
+exports[`toContainMatchingElements with a mount wrapper provides contextual information for the message 2`] = `
+Object {
+  "actual": "Element tree for <Fixture>:
+ <Fixture>
+  <div>
+    <ul>
+      <li>
+        <User index={1} className=\\"userOne\\">
+          <span className=\\"userOne\\">
+            User 
+            <span data-index=\\"value-1\\">
+              1
+            </span>
+          </span>
+        </User>
+      </li>
+      <li>
+        <User index={2} className=\\"userTwo\\">
+          <span className=\\"userTwo\\">
+            User 
+            <span data-index=\\"value-2\\">
+              2
+            </span>
+          </span>
+        </User>
+      </li>
+    </ul>
+  </div>
+</Fixture>",
+}
+`;
+
+exports[`toContainMatchingElements with a mount wrapper provides contextual information for the message 3`] = `
+Object {
+  "actual": "Element tree for <Fixture>:
+ <Fixture>
+  <div>
+    <ul>
+      <li>
+        <User index={1} className=\\"userOne\\">
+          <span className=\\"userOne\\">
+            User 
+            <span data-index=\\"value-1\\">
+              1
+            </span>
+          </span>
+        </User>
+      </li>
+      <li>
+        <User index={2} className=\\"userTwo\\">
+          <span className=\\"userTwo\\">
+            User 
+            <span data-index=\\"value-2\\">
+              2
+            </span>
+          </span>
+        </User>
+      </li>
+    </ul>
+  </div>
+</Fixture>",
+}
+`;
+
+exports[`toContainMatchingElements with a mount wrapper provides contextual information for the message 4`] = `
+Object {
+  "actual": "Element tree for <ul>:
+ <ul>
+  <li>
+    <User index={1} className=\\"userOne\\">
+      <span className=\\"userOne\\">
+        User 
+        <span data-index=\\"value-1\\">
+          1
+        </span>
+      </span>
+    </User>
+  </li>
+  <li>
+    <User index={2} className=\\"userTwo\\">
+      <span className=\\"userTwo\\">
+        User 
+        <span data-index=\\"value-2\\">
+          2
+        </span>
+      </span>
+    </User>
+  </li>
+</ul>",
+}
+`;
+
+exports[`toContainMatchingElements with a mount wrapper provides contextual information for the message 5`] = `
+Object {
+  "actual": "Element tree for <2 (anonymous) nodes found>:
+ Multiple nodes found:
+0: <function User(props) {
+  return React.createElement(\\"span\\", {
+    className: props.className
+  }, \\"User \\", React.createElement(\\"span\\", {
+    \\"data-index\\": \`value-\${props.index}\`
+  }, props.index));
+} index=\\"1\\" className=\\"userOne\\"/>
+1: <function User(props) {
+  return React.createElement(\\"span\\", {
+    className: props.className
+  }, \\"User \\", React.createElement(\\"span\\", {
+    \\"data-index\\": \`value-\${props.index}\`
+  }, props.index));
+} index=\\"2\\" className=\\"userTwo\\"/>
+",
+}
+`;
+
+exports[`toContainMatchingElements with a mount wrapper provides contextual information for the message 6`] = `
+Object {
+  "actual": "Element tree for <Fixture>:
+ <Fixture>
+  <div>
+    <ul>
+      <li>
+        <User index={1} className=\\"userOne\\">
+          <span className=\\"userOne\\">
+            User 
+            <span data-index=\\"value-1\\">
+              1
+            </span>
+          </span>
+        </User>
+      </li>
+      <li>
+        <User index={2} className=\\"userTwo\\">
+          <span className=\\"userTwo\\">
+            User 
+            <span data-index=\\"value-2\\">
+              2
+            </span>
+          </span>
+        </User>
+      </li>
+    </ul>
+  </div>
+</Fixture>",
+}
+`;
+
+exports[`toContainMatchingElements with a mount wrapper provides contextual information for the message 7`] = `
+Object {
+  "actual": "Element tree for <Fixture>:
+ <Fixture>
+  <div>
+    <ul>
+      <li>
+        <User index={1} className=\\"userOne\\">
+          <span className=\\"userOne\\">
+            User 
+            <span data-index=\\"value-1\\">
+              1
+            </span>
+          </span>
+        </User>
+      </li>
+      <li>
+        <User index={2} className=\\"userTwo\\">
+          <span className=\\"userTwo\\">
+            User 
+            <span data-index=\\"value-2\\">
+              2
+            </span>
+          </span>
+        </User>
+      </li>
+    </ul>
+  </div>
+</Fixture>",
+}
+`;
+
+exports[`toContainMatchingElements with a mount wrapper provides contextual information for the message 8`] = `
+Object {
+  "actual": "Element tree for <Fixture>:
+ <Fixture>
+  <div>
+    <ul>
+      <li>
+        <User index={1} className=\\"userOne\\">
+          <span className=\\"userOne\\">
+            User 
+            <span data-index=\\"value-1\\">
+              1
+            </span>
+          </span>
+        </User>
+      </li>
+      <li>
+        <User index={2} className=\\"userTwo\\">
+          <span className=\\"userTwo\\">
+            User 
+            <span data-index=\\"value-2\\">
+              2
+            </span>
+          </span>
+        </User>
+      </li>
+    </ul>
+  </div>
+</Fixture>",
+}
+`;
+
+exports[`toContainMatchingElements with a mount wrapper provides contextual information for the message 9`] = `
+Object {
+  "actual": "Element tree for <ul>:
+ <ul>
+  <li>
+    <User index={1} className=\\"userOne\\">
+      <span className=\\"userOne\\">
+        User 
+        <span data-index=\\"value-1\\">
+          1
+        </span>
+      </span>
+    </User>
+  </li>
+  <li>
+    <User index={2} className=\\"userTwo\\">
+      <span className=\\"userTwo\\">
+        User 
+        <span data-index=\\"value-2\\">
+          2
+        </span>
+      </span>
+    </User>
+  </li>
+</ul>",
+}
+`;
+
+exports[`toContainMatchingElements with a mount wrapper provides contextual information for the message 10`] = `
+Object {
+  "actual": "Element tree for <Fixture>:
+ <Fixture>
+  <div>
+    <ul>
+      <li>
+        <User index={1} className=\\"userOne\\">
+          <span className=\\"userOne\\">
+            User 
+            <span data-index=\\"value-1\\">
+              1
+            </span>
+          </span>
+        </User>
+      </li>
+      <li>
+        <User index={2} className=\\"userTwo\\">
+          <span className=\\"userTwo\\">
+            User 
+            <span data-index=\\"value-2\\">
+              2
+            </span>
+          </span>
+        </User>
+      </li>
+    </ul>
+  </div>
+</Fixture>",
+}
+`;
+
+exports[`toContainMatchingElements with a mount wrapper provides contextual information for the message 11`] = `
+Object {
+  "actual": "Element tree for <Fixture>:
+ <Fixture>
+  <div>
+    <ul>
+      <li>
+        <User index={1} className=\\"userOne\\">
+          <span className=\\"userOne\\">
+            User 
+            <span data-index=\\"value-1\\">
+              1
+            </span>
+          </span>
+        </User>
+      </li>
+      <li>
+        <User index={2} className=\\"userTwo\\">
+          <span className=\\"userTwo\\">
+            User 
+            <span data-index=\\"value-2\\">
+              2
+            </span>
+          </span>
+        </User>
+      </li>
+    </ul>
+  </div>
+</Fixture>",
+}
+`;
+
+exports[`toContainMatchingElements with a mount wrapper provides contextual information for the message 12`] = `
+Object {
+  "actual": "Element tree for <Fixture>:
+ <Fixture>
+  <div>
+    <ul>
+      <li>
+        <User index={1} className=\\"userOne\\">
+          <span className=\\"userOne\\">
+            User 
+            <span data-index=\\"value-1\\">
+              1
+            </span>
+          </span>
+        </User>
+      </li>
+      <li>
+        <User index={2} className=\\"userTwo\\">
+          <span className=\\"userTwo\\">
+            User 
+            <span data-index=\\"value-2\\">
+              2
+            </span>
+          </span>
+        </User>
+      </li>
+    </ul>
+  </div>
+</Fixture>",
+}
+`;
+
+exports[`toContainMatchingElements with a mount wrapper provides contextual information for the message 13`] = `
+Object {
+  "actual": "Element tree for <Fixture>:
+ <Fixture>
+  <div>
+    <ul>
+      <li>
+        <User index={1} className=\\"userOne\\">
+          <span className=\\"userOne\\">
+            User 
+            <span data-index=\\"value-1\\">
+              1
+            </span>
+          </span>
+        </User>
+      </li>
+      <li>
+        <User index={2} className=\\"userTwo\\">
+          <span className=\\"userTwo\\">
+            User 
+            <span data-index=\\"value-2\\">
+              2
+            </span>
+          </span>
+        </User>
+      </li>
+    </ul>
+  </div>
+</Fixture>",
+}
+`;
+
+exports[`toContainMatchingElements with a mount wrapper returns the proper verbage for "1 .userThree" 1`] = `"Expected <Fixture> to not contain 1 element matching \\".userThree\\" but it did."`;
+
+exports[`toContainMatchingElements with a mount wrapper returns the proper verbage for "1 [data-index="value-1"]" 1`] = `"Expected <Fixture> to contain 1 element matching \\"[data-index=\\"value-1\\"]\\" but 1 was found."`;
+
+exports[`toContainMatchingElements with a mount wrapper returns the proper verbage for "1 [data-index]" 1`] = `"Expected <Fixture> to not contain 1 element matching \\"[data-index]\\" but it did."`;
+
+exports[`toContainMatchingElements with a mount wrapper returns the proper verbage for "1 [index=1] in User" 1`] = `"Expected <2 (anonymous) nodes found> to contain 1 element matching \\"[index=1]\\" but 1 was found."`;
+
+exports[`toContainMatchingElements with a mount wrapper returns the proper verbage for "1 [index=1]" 1`] = `"Expected <Fixture> to contain 1 element matching \\"[index=1]\\" but 1 was found."`;
+
+exports[`toContainMatchingElements with a mount wrapper returns the proper verbage for "1 [index]" 1`] = `"Expected <Fixture> to not contain 1 element matching \\"[index]\\" but it did."`;
+
+exports[`toContainMatchingElements with a mount wrapper returns the proper verbage for "2 .userOne" 1`] = `"Expected <Fixture> to contain 2 elements matching \\".userOne\\" but 2 were found."`;
+
+exports[`toContainMatchingElements with a mount wrapper returns the proper verbage for "2 [data-index]" 1`] = `"Expected <Fixture> to contain 2 elements matching \\"[data-index]\\" but 2 were found."`;
+
+exports[`toContainMatchingElements with a mount wrapper returns the proper verbage for "2 [index] in ul" 1`] = `"Expected <ul> to contain 2 elements matching \\"[index]\\" but 2 were found."`;
+
+exports[`toContainMatchingElements with a mount wrapper returns the proper verbage for "2 [index]" 1`] = `"Expected <Fixture> to contain 2 elements matching \\"[index]\\" but 2 were found."`;
+
+exports[`toContainMatchingElements with a mount wrapper returns the proper verbage for "2 User" 1`] = `"Expected <Fixture> to contain 2 elements matching \\"User\\" but 2 were found."`;
+
+exports[`toContainMatchingElements with a mount wrapper returns the proper verbage for "3 [index] in ul" 1`] = `"Expected <ul> to not contain 3 elements matching \\"[index]\\" but it did."`;
+
+exports[`toContainMatchingElements with a mount wrapper returns the proper verbage for "3 User" 1`] = `"Expected <Fixture> to not contain 3 elements matching \\"User\\" but it did."`;
+
+exports[`toContainMatchingElements with a shallow wrapper provides contextual information for the message 1`] = `
 Object {
   "actual": "Element tree for <div>:
  <div>
@@ -16,7 +440,7 @@ Object {
 }
 `;
 
-exports[`toContainMatchingElements provides contextual information for the message 2`] = `
+exports[`toContainMatchingElements with a shallow wrapper provides contextual information for the message 2`] = `
 Object {
   "actual": "Element tree for <div>:
  <div>
@@ -32,7 +456,7 @@ Object {
 }
 `;
 
-exports[`toContainMatchingElements provides contextual information for the message 3`] = `
+exports[`toContainMatchingElements with a shallow wrapper provides contextual information for the message 3`] = `
 Object {
   "actual": "Element tree for <div>:
  <div>
@@ -48,7 +472,7 @@ Object {
 }
 `;
 
-exports[`toContainMatchingElements provides contextual information for the message 4`] = `
+exports[`toContainMatchingElements with a shallow wrapper provides contextual information for the message 4`] = `
 Object {
   "actual": "Element tree for <ul>:
  <ul>
@@ -62,38 +486,176 @@ Object {
 }
 `;
 
-exports[`toContainMatchingElements provides contextual information for the message 5`] = `
+exports[`toContainMatchingElements with a shallow wrapper provides contextual information for the message 5`] = `
 Object {
   "actual": "Element tree for <2 (anonymous) nodes found>:
  Multiple nodes found:
 0: <function User(props) {
   return React.createElement(\\"span\\", {
     className: props.className
-  }, \\"User \\", props.index);
+  }, \\"User \\", React.createElement(\\"span\\", {
+    \\"data-index\\": \`value-\${props.index}\`
+  }, props.index));
 } index=\\"1\\" className=\\"userOne\\"/>
 1: <function User(props) {
   return React.createElement(\\"span\\", {
     className: props.className
-  }, \\"User \\", props.index);
+  }, \\"User \\", React.createElement(\\"span\\", {
+    \\"data-index\\": \`value-\${props.index}\`
+  }, props.index));
 } index=\\"2\\" className=\\"userTwo\\"/>
 ",
 }
 `;
 
-exports[`toContainMatchingElements returns the message with the proper fail verbage 1`] = `"Expected <div> to not contain 3 elements matching \\"User\\" but it did."`;
+exports[`toContainMatchingElements with a shallow wrapper provides contextual information for the message 6`] = `
+Object {
+  "actual": "Element tree for <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
+}
+`;
 
-exports[`toContainMatchingElements returns the message with the proper fail verbage 2`] = `"Expected <div> to not contain 1 element matching \\".userThree\\" but it did."`;
+exports[`toContainMatchingElements with a shallow wrapper provides contextual information for the message 7`] = `
+Object {
+  "actual": "Element tree for <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
+}
+`;
 
-exports[`toContainMatchingElements returns the message with the proper fail verbage 3`] = `"Expected <div> to not contain 1 element matching \\"[index]\\" but it did."`;
+exports[`toContainMatchingElements with a shallow wrapper provides contextual information for the message 8`] = `
+Object {
+  "actual": "Element tree for <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
+}
+`;
 
-exports[`toContainMatchingElements returns the message with the proper fail verbage 4`] = `"Expected <ul> to not contain 3 elements matching \\"[index]\\" but it did."`;
+exports[`toContainMatchingElements with a shallow wrapper provides contextual information for the message 9`] = `
+Object {
+  "actual": "Element tree for <ul>:
+ <ul>
+  <li>
+    <User index={1} className=\\"userOne\\" />
+  </li>
+  <li>
+    <User index={2} className=\\"userTwo\\" />
+  </li>
+</ul>",
+}
+`;
 
-exports[`toContainMatchingElements returns the message with the proper pass verbage 1`] = `"Expected <div> to contain 2 elements matching \\"User\\" but 2 were found."`;
+exports[`toContainMatchingElements with a shallow wrapper provides contextual information for the message 10`] = `
+Object {
+  "actual": "Element tree for <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
+}
+`;
 
-exports[`toContainMatchingElements returns the message with the proper pass verbage 2`] = `"Expected <div> to contain 1 element matching \\"[index=1]\\" but 1 was found."`;
+exports[`toContainMatchingElements with a shallow wrapper provides contextual information for the message 11`] = `
+Object {
+  "actual": "Element tree for <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
+}
+`;
 
-exports[`toContainMatchingElements returns the message with the proper pass verbage 3`] = `"Expected <div> to contain 2 elements matching \\"[index]\\" but 2 were found."`;
+exports[`toContainMatchingElements with a shallow wrapper provides contextual information for the message 12`] = `
+Object {
+  "actual": "Element tree for <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
+}
+`;
 
-exports[`toContainMatchingElements returns the message with the proper pass verbage 4`] = `"Expected <ul> to contain 2 elements matching \\"[index]\\" but 2 were found."`;
+exports[`toContainMatchingElements with a shallow wrapper provides contextual information for the message 13`] = `
+Object {
+  "actual": "Element tree for <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
+}
+`;
 
-exports[`toContainMatchingElements returns the message with the proper pass verbage 5`] = `"Expected <2 (anonymous) nodes found> to contain 1 element matching \\"[index=1]\\" but 1 was found."`;
+exports[`toContainMatchingElements with a shallow wrapper returns the proper verbage for "0 [data-index]" 1`] = `"Expected <div> to contain 0 elements matching \\"[data-index]\\" but 0 were found."`;
+
+exports[`toContainMatchingElements with a shallow wrapper returns the proper verbage for "1 .userOne" 1`] = `"Expected <div> to contain 1 element matching \\".userOne\\" but 1 was found."`;
+
+exports[`toContainMatchingElements with a shallow wrapper returns the proper verbage for "1 .userThree" 1`] = `"Expected <div> to not contain 1 element matching \\".userThree\\" but it did."`;
+
+exports[`toContainMatchingElements with a shallow wrapper returns the proper verbage for "1 [data-index="value-1"]" 1`] = `"Expected <div> to not contain 1 element matching \\"[data-index=\\"value-1\\"]\\" but it did."`;
+
+exports[`toContainMatchingElements with a shallow wrapper returns the proper verbage for "1 [data-index]" 1`] = `"Expected <div> to not contain 1 element matching \\"[data-index]\\" but it did."`;
+
+exports[`toContainMatchingElements with a shallow wrapper returns the proper verbage for "1 [index=1] in User" 1`] = `"Expected <2 (anonymous) nodes found> to contain 1 element matching \\"[index=1]\\" but 1 was found."`;
+
+exports[`toContainMatchingElements with a shallow wrapper returns the proper verbage for "1 [index=1]" 1`] = `"Expected <div> to contain 1 element matching \\"[index=1]\\" but 1 was found."`;
+
+exports[`toContainMatchingElements with a shallow wrapper returns the proper verbage for "1 [index]" 1`] = `"Expected <div> to not contain 1 element matching \\"[index]\\" but it did."`;
+
+exports[`toContainMatchingElements with a shallow wrapper returns the proper verbage for "2 [index] in ul" 1`] = `"Expected <ul> to contain 2 elements matching \\"[index]\\" but 2 were found."`;
+
+exports[`toContainMatchingElements with a shallow wrapper returns the proper verbage for "2 [index]" 1`] = `"Expected <div> to contain 2 elements matching \\"[index]\\" but 2 were found."`;
+
+exports[`toContainMatchingElements with a shallow wrapper returns the proper verbage for "2 User" 1`] = `"Expected <div> to contain 2 elements matching \\"User\\" but 2 were found."`;
+
+exports[`toContainMatchingElements with a shallow wrapper returns the proper verbage for "3 [index] in ul" 1`] = `"Expected <ul> to not contain 3 elements matching \\"[index]\\" but it did."`;
+
+exports[`toContainMatchingElements with a shallow wrapper returns the proper verbage for "3 User" 1`] = `"Expected <div> to not contain 3 elements matching \\"User\\" but it did."`;

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainMatchingElements.test.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainMatchingElements.test.js.snap
@@ -2,35 +2,69 @@
 
 exports[`toContainMatchingElements provides contextual information for the message 1`] = `
 Object {
-  "actual": "HTML Output of <div>:
- <div><ul><li><User index={1} className=\\"userOne\\" /></li><li><User index={2} className=\\"userTwo\\" /></li></ul></div>",
+  "actual": "Element tree for <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
 }
 `;
 
 exports[`toContainMatchingElements provides contextual information for the message 2`] = `
 Object {
-  "actual": "HTML Output of <div>:
- <div><ul><li><User index={1} className=\\"userOne\\" /></li><li><User index={2} className=\\"userTwo\\" /></li></ul></div>",
+  "actual": "Element tree for <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
 }
 `;
 
 exports[`toContainMatchingElements provides contextual information for the message 3`] = `
 Object {
-  "actual": "HTML Output of <div>:
- <div><ul><li><User index={1} className=\\"userOne\\" /></li><li><User index={2} className=\\"userTwo\\" /></li></ul></div>",
+  "actual": "Element tree for <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
 }
 `;
 
 exports[`toContainMatchingElements provides contextual information for the message 4`] = `
 Object {
-  "actual": "HTML Output of <ul>:
- <ul><li><User index={1} className=\\"userOne\\" /></li><li><User index={2} className=\\"userTwo\\" /></li></ul>",
+  "actual": "Element tree for <ul>:
+ <ul>
+  <li>
+    <User index={1} className=\\"userOne\\" />
+  </li>
+  <li>
+    <User index={2} className=\\"userTwo\\" />
+  </li>
+</ul>",
 }
 `;
 
 exports[`toContainMatchingElements provides contextual information for the message 5`] = `
 Object {
-  "actual": "HTML Output of <2 (anonymous) nodes found>:
+  "actual": "Element tree for <2 (anonymous) nodes found>:
  Multiple nodes found:
 0: <function User(props) {
   return React.createElement(\\"span\\", {

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainMatchingNode.test.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainMatchingNode.test.js.snap
@@ -1,0 +1,158 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`toContainMatchingNode with a mount wrapper provides contextual information for the message 1`] = `
+Object {
+  "actual": "HTML Output of <Fixture>:
+ <div><ul><li><span class=\\"userOne\\">User <span data-index=\\"value-1\\">1</span></span></li><li><span class=\\"userTwo\\">User <span data-index=\\"value-2\\">2</span></span></li></ul></div>",
+}
+`;
+
+exports[`toContainMatchingNode with a mount wrapper provides contextual information for the message 2`] = `
+Object {
+  "actual": "HTML Output of <Fixture>:
+ <div><ul><li><span class=\\"userOne\\">User <span data-index=\\"value-1\\">1</span></span></li><li><span class=\\"userTwo\\">User <span data-index=\\"value-2\\">2</span></span></li></ul></div>",
+}
+`;
+
+exports[`toContainMatchingNode with a mount wrapper provides contextual information for the message 3`] = `
+Object {
+  "actual": "HTML Output of <Fixture>:
+ <div><ul><li><span class=\\"userOne\\">User <span data-index=\\"value-1\\">1</span></span></li><li><span class=\\"userTwo\\">User <span data-index=\\"value-2\\">2</span></span></li></ul></div>",
+}
+`;
+
+exports[`toContainMatchingNode with a mount wrapper provides contextual information for the message 4`] = `
+Object {
+  "actual": "HTML Output of <2 (anonymous) nodes found>:
+ Multiple nodes found:
+0: <function User(props) {
+  return React.createElement(\\"span\\", {
+    className: props.className
+  }, \\"User \\", React.createElement(\\"span\\", {
+    \\"data-index\\": \`value-\${props.index}\`
+  }, props.index));
+} index=\\"1\\" className=\\"userOne\\"/>
+1: <function User(props) {
+  return React.createElement(\\"span\\", {
+    className: props.className
+  }, \\"User \\", React.createElement(\\"span\\", {
+    \\"data-index\\": \`value-\${props.index}\`
+  }, props.index));
+} index=\\"2\\" className=\\"userTwo\\"/>
+",
+}
+`;
+
+exports[`toContainMatchingNode with a mount wrapper provides contextual information for the message 5`] = `
+Object {
+  "actual": "HTML Output of <2 (anonymous) nodes found>:
+ Multiple nodes found:
+0: <function User(props) {
+  return React.createElement(\\"span\\", {
+    className: props.className
+  }, \\"User \\", React.createElement(\\"span\\", {
+    \\"data-index\\": \`value-\${props.index}\`
+  }, props.index));
+} index=\\"1\\" className=\\"userOne\\"/>
+1: <function User(props) {
+  return React.createElement(\\"span\\", {
+    className: props.className
+  }, \\"User \\", React.createElement(\\"span\\", {
+    \\"data-index\\": \`value-\${props.index}\`
+  }, props.index));
+} index=\\"2\\" className=\\"userTwo\\"/>
+",
+}
+`;
+
+exports[`toContainMatchingNode with a mount wrapper returns the proper verbage for ".userOne" 1`] = `"Expected <Fixture> to contain at least one node matching \\".userOne\\" but none were found."`;
+
+exports[`toContainMatchingNode with a mount wrapper returns the proper verbage for ".userOne" 2`] = `"Expected <2 (anonymous) nodes found> to contain at least one node matching \\".userOne\\" but none were found."`;
+
+exports[`toContainMatchingNode with a mount wrapper returns the proper verbage for "[data-index="value-1"]" 1`] = `"Expected <Fixture> to contain at least one node matching \\"[data-index=\\"value-1\\"]\\" but none were found."`;
+
+exports[`toContainMatchingNode with a mount wrapper returns the proper verbage for "[data-index="value-1"]" 2`] = `"Expected <2 (anonymous) nodes found> to contain at least one node matching \\"[data-index=\\"value-1\\"]\\" but none were found."`;
+
+exports[`toContainMatchingNode with a mount wrapper returns the proper verbage for "[data-index]" 1`] = `"Expected <Fixture> to contain at least one node matching \\"[data-index]\\" but none were found."`;
+
+exports[`toContainMatchingNode with a shallow wrapper provides contextual information for the message 1`] = `
+Object {
+  "actual": "HTML Output of <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
+}
+`;
+
+exports[`toContainMatchingNode with a shallow wrapper provides contextual information for the message 2`] = `
+Object {
+  "actual": "HTML Output of <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
+}
+`;
+
+exports[`toContainMatchingNode with a shallow wrapper provides contextual information for the message 3`] = `
+Object {
+  "actual": "HTML Output of <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
+}
+`;
+
+exports[`toContainMatchingNode with a shallow wrapper provides contextual information for the message 4`] = `
+Object {
+  "actual": "HTML Output of <span>:
+ <span className=\\"userOne\\">
+  User 
+  <span data-index=\\"value-1\\">
+    1
+  </span>
+</span>",
+}
+`;
+
+exports[`toContainMatchingNode with a shallow wrapper provides contextual information for the message 5`] = `
+Object {
+  "actual": "HTML Output of <span>:
+ <span className=\\"userOne\\">
+  User 
+  <span data-index=\\"value-1\\">
+    1
+  </span>
+</span>",
+}
+`;
+
+exports[`toContainMatchingNode with a shallow wrapper returns the proper verbage for ".userOne" 1`] = `"Expected <div> to not contain a node matching \\".userOne\\" but it did."`;
+
+exports[`toContainMatchingNode with a shallow wrapper returns the proper verbage for ".userOne" 2`] = `"Expected <span> to contain at least one node matching \\".userOne\\" but none were found."`;
+
+exports[`toContainMatchingNode with a shallow wrapper returns the proper verbage for "[data-index="value-1"]" 1`] = `"Expected <div> to not contain a node matching \\"[data-index=\\"value-1\\"]\\" but it did."`;
+
+exports[`toContainMatchingNode with a shallow wrapper returns the proper verbage for "[data-index="value-1"]" 2`] = `"Expected <span> to contain at least one node matching \\"[data-index=\\"value-1\\"]\\" but none were found."`;
+
+exports[`toContainMatchingNode with a shallow wrapper returns the proper verbage for "[data-index]" 1`] = `"Expected <div> to not contain a node matching \\"[data-index]\\" but it did."`;

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainMatchingNodes.test.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainMatchingNodes.test.js.snap
@@ -1,0 +1,324 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`toContainMatchingNodes provides contextual information for the message 1`] = `
+Object {
+  "actual": "HTML Output of <Fixture>:
+ <div><ul><li><span class=\\"userOne\\">User <span data-index=\\"value-1\\">1</span></span></li><li><span class=\\"userTwo\\">User <span data-index=\\"value-2\\">2</span></span></li></ul></div>",
+}
+`;
+
+exports[`toContainMatchingNodes provides contextual information for the message 2`] = `
+Object {
+  "actual": "HTML Output of <Fixture>:
+ <div><ul><li><span class=\\"userOne\\">User <span data-index=\\"value-1\\">1</span></span></li><li><span class=\\"userTwo\\">User <span data-index=\\"value-2\\">2</span></span></li></ul></div>",
+}
+`;
+
+exports[`toContainMatchingNodes provides contextual information for the message 3`] = `
+Object {
+  "actual": "HTML Output of <Fixture>:
+ <div><ul><li><span class=\\"userOne\\">User <span data-index=\\"value-1\\">1</span></span></li><li><span class=\\"userTwo\\">User <span data-index=\\"value-2\\">2</span></span></li></ul></div>",
+}
+`;
+
+exports[`toContainMatchingNodes provides contextual information for the message 4`] = `
+Object {
+  "actual": "HTML Output of <ul>:
+ <ul><li><span class=\\"userOne\\">User <span data-index=\\"value-1\\">1</span></span></li><li><span class=\\"userTwo\\">User <span data-index=\\"value-2\\">2</span></span></li></ul>",
+}
+`;
+
+exports[`toContainMatchingNodes provides contextual information for the message 5`] = `
+Object {
+  "actual": "HTML Output of <2 (anonymous) nodes found>:
+ Multiple nodes found:
+0: <function User(props) {
+  return React.createElement(\\"span\\", {
+    className: props.className
+  }, \\"User \\", React.createElement(\\"span\\", {
+    \\"data-index\\": \`value-\${props.index}\`
+  }, props.index));
+} index=\\"1\\" className=\\"userOne\\"/>
+1: <function User(props) {
+  return React.createElement(\\"span\\", {
+    className: props.className
+  }, \\"User \\", React.createElement(\\"span\\", {
+    \\"data-index\\": \`value-\${props.index}\`
+  }, props.index));
+} index=\\"2\\" className=\\"userTwo\\"/>
+",
+}
+`;
+
+exports[`toContainMatchingNodes provides contextual information for the message 6`] = `
+Object {
+  "actual": "HTML Output of <Fixture>:
+ <div><ul><li><span class=\\"userOne\\">User <span data-index=\\"value-1\\">1</span></span></li><li><span class=\\"userTwo\\">User <span data-index=\\"value-2\\">2</span></span></li></ul></div>",
+}
+`;
+
+exports[`toContainMatchingNodes provides contextual information for the message 7`] = `
+Object {
+  "actual": "HTML Output of <Fixture>:
+ <div><ul><li><span class=\\"userOne\\">User <span data-index=\\"value-1\\">1</span></span></li><li><span class=\\"userTwo\\">User <span data-index=\\"value-2\\">2</span></span></li></ul></div>",
+}
+`;
+
+exports[`toContainMatchingNodes provides contextual information for the message 8`] = `
+Object {
+  "actual": "HTML Output of <ul>:
+ <ul><li><span class=\\"userOne\\">User <span data-index=\\"value-1\\">1</span></span></li><li><span class=\\"userTwo\\">User <span data-index=\\"value-2\\">2</span></span></li></ul>",
+}
+`;
+
+exports[`toContainMatchingNodes returns the proper verbage for "1 .userOne" 1`] = `"Expected <Fixture> to contain 1 node matching \\".userOne\\" but 1 was found."`;
+
+exports[`toContainMatchingNodes returns the proper verbage for "1 .userThree" 1`] = `"Expected <Fixture> to not contain 1 node matching \\".userThree\\" but it did."`;
+
+exports[`toContainMatchingNodes returns the proper verbage for "1 [data-index="value-1"] in User" 1`] = `"Expected <2 (anonymous) nodes found> to contain 1 node matching \\"[data-index=\\"value-1\\"]\\" but 1 was found."`;
+
+exports[`toContainMatchingNodes returns the proper verbage for "1 [data-index="value-1"]" 1`] = `"Expected <Fixture> to contain 1 node matching \\"[data-index=\\"value-1\\"]\\" but 1 was found."`;
+
+exports[`toContainMatchingNodes returns the proper verbage for "1 [data-index]" 1`] = `"Expected <Fixture> to not contain 1 node matching \\"[data-index]\\" but it did."`;
+
+exports[`toContainMatchingNodes returns the proper verbage for "2 [data-index] in ul" 1`] = `"Expected <ul> to contain 2 nodes matching \\"[data-index]\\" but 2 were found."`;
+
+exports[`toContainMatchingNodes returns the proper verbage for "2 [data-index]" 1`] = `"Expected <Fixture> to contain 2 nodes matching \\"[data-index]\\" but 2 were found."`;
+
+exports[`toContainMatchingNodes returns the proper verbage for "3 [data-index] in ul" 1`] = `"Expected <ul> to not contain 3 nodes matching \\"[data-index]\\" but it did."`;
+
+exports[`toContainMatchingNodes with a mount wrapper provides contextual information for the message 1`] = `
+Object {
+  "actual": "HTML Output of <Fixture>:
+ <div><ul><li><span class=\\"userOne\\">User <span data-index=\\"value-1\\">1</span></span></li><li><span class=\\"userTwo\\">User <span data-index=\\"value-2\\">2</span></span></li></ul></div>",
+}
+`;
+
+exports[`toContainMatchingNodes with a mount wrapper provides contextual information for the message 2`] = `
+Object {
+  "actual": "HTML Output of <Fixture>:
+ <div><ul><li><span class=\\"userOne\\">User <span data-index=\\"value-1\\">1</span></span></li><li><span class=\\"userTwo\\">User <span data-index=\\"value-2\\">2</span></span></li></ul></div>",
+}
+`;
+
+exports[`toContainMatchingNodes with a mount wrapper provides contextual information for the message 3`] = `
+Object {
+  "actual": "HTML Output of <Fixture>:
+ <div><ul><li><span class=\\"userOne\\">User <span data-index=\\"value-1\\">1</span></span></li><li><span class=\\"userTwo\\">User <span data-index=\\"value-2\\">2</span></span></li></ul></div>",
+}
+`;
+
+exports[`toContainMatchingNodes with a mount wrapper provides contextual information for the message 4`] = `
+Object {
+  "actual": "HTML Output of <2 (anonymous) nodes found>:
+ Multiple nodes found:
+0: <function User(props) {
+  return React.createElement(\\"span\\", {
+    className: props.className
+  }, \\"User \\", React.createElement(\\"span\\", {
+    \\"data-index\\": \`value-\${props.index}\`
+  }, props.index));
+} index=\\"1\\" className=\\"userOne\\"/>
+1: <function User(props) {
+  return React.createElement(\\"span\\", {
+    className: props.className
+  }, \\"User \\", React.createElement(\\"span\\", {
+    \\"data-index\\": \`value-\${props.index}\`
+  }, props.index));
+} index=\\"2\\" className=\\"userTwo\\"/>
+",
+}
+`;
+
+exports[`toContainMatchingNodes with a mount wrapper provides contextual information for the message 5`] = `
+Object {
+  "actual": "HTML Output of <2 (anonymous) nodes found>:
+ Multiple nodes found:
+0: <function User(props) {
+  return React.createElement(\\"span\\", {
+    className: props.className
+  }, \\"User \\", React.createElement(\\"span\\", {
+    \\"data-index\\": \`value-\${props.index}\`
+  }, props.index));
+} index=\\"1\\" className=\\"userOne\\"/>
+1: <function User(props) {
+  return React.createElement(\\"span\\", {
+    className: props.className
+  }, \\"User \\", React.createElement(\\"span\\", {
+    \\"data-index\\": \`value-\${props.index}\`
+  }, props.index));
+} index=\\"2\\" className=\\"userTwo\\"/>
+",
+}
+`;
+
+exports[`toContainMatchingNodes with a mount wrapper provides contextual information for the message 6`] = `
+Object {
+  "actual": "HTML Output of <ul>:
+ <ul><li><span class=\\"userOne\\">User <span data-index=\\"value-1\\">1</span></span></li><li><span class=\\"userTwo\\">User <span data-index=\\"value-2\\">2</span></span></li></ul>",
+}
+`;
+
+exports[`toContainMatchingNodes with a mount wrapper provides contextual information for the message 7`] = `
+Object {
+  "actual": "HTML Output of <Fixture>:
+ <div><ul><li><span class=\\"userOne\\">User <span data-index=\\"value-1\\">1</span></span></li><li><span class=\\"userTwo\\">User <span data-index=\\"value-2\\">2</span></span></li></ul></div>",
+}
+`;
+
+exports[`toContainMatchingNodes with a mount wrapper provides contextual information for the message 8`] = `
+Object {
+  "actual": "HTML Output of <Fixture>:
+ <div><ul><li><span class=\\"userOne\\">User <span data-index=\\"value-1\\">1</span></span></li><li><span class=\\"userTwo\\">User <span data-index=\\"value-2\\">2</span></span></li></ul></div>",
+}
+`;
+
+exports[`toContainMatchingNodes with a mount wrapper returns the proper verbage for "1 .userOne in User" 1`] = `"Expected <2 (anonymous) nodes found> to contain 1 node matching \\".userOne\\" but 1 was found."`;
+
+exports[`toContainMatchingNodes with a mount wrapper returns the proper verbage for "1 .userOne" 1`] = `"Expected <Fixture> to contain 1 node matching \\".userOne\\" but 1 was found."`;
+
+exports[`toContainMatchingNodes with a mount wrapper returns the proper verbage for "1 .userThree" 1`] = `"Expected <Fixture> to not contain 1 node matching \\".userThree\\" but it did."`;
+
+exports[`toContainMatchingNodes with a mount wrapper returns the proper verbage for "1 [data-index="value-1"] in User" 1`] = `"Expected <2 (anonymous) nodes found> to contain 1 node matching \\"[data-index=\\"value-1\\"]\\" but 1 was found."`;
+
+exports[`toContainMatchingNodes with a mount wrapper returns the proper verbage for "1 [data-index="value-1"]" 1`] = `"Expected <Fixture> to contain 1 node matching \\"[data-index=\\"value-1\\"]\\" but 1 was found."`;
+
+exports[`toContainMatchingNodes with a mount wrapper returns the proper verbage for "1 [data-index]" 1`] = `"Expected <Fixture> to not contain 1 node matching \\"[data-index]\\" but it did."`;
+
+exports[`toContainMatchingNodes with a mount wrapper returns the proper verbage for "2 [data-index] in ul" 1`] = `"Expected <ul> to contain 2 nodes matching \\"[data-index]\\" but 2 were found."`;
+
+exports[`toContainMatchingNodes with a mount wrapper returns the proper verbage for "2 [data-index]" 1`] = `"Expected <Fixture> to contain 2 nodes matching \\"[data-index]\\" but 2 were found."`;
+
+exports[`toContainMatchingNodes with a shallow wrapper provides contextual information for the message 1`] = `
+Object {
+  "actual": "HTML Output of <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
+}
+`;
+
+exports[`toContainMatchingNodes with a shallow wrapper provides contextual information for the message 2`] = `
+Object {
+  "actual": "HTML Output of <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
+}
+`;
+
+exports[`toContainMatchingNodes with a shallow wrapper provides contextual information for the message 3`] = `
+Object {
+  "actual": "HTML Output of <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
+}
+`;
+
+exports[`toContainMatchingNodes with a shallow wrapper provides contextual information for the message 4`] = `
+Object {
+  "actual": "HTML Output of <span>:
+ <span className=\\"userOne\\">
+  User 
+  <span data-index=\\"value-1\\">
+    1
+  </span>
+</span>",
+}
+`;
+
+exports[`toContainMatchingNodes with a shallow wrapper provides contextual information for the message 5`] = `
+Object {
+  "actual": "HTML Output of <span>:
+ <span className=\\"userOne\\">
+  User 
+  <span data-index=\\"value-1\\">
+    1
+  </span>
+</span>",
+}
+`;
+
+exports[`toContainMatchingNodes with a shallow wrapper provides contextual information for the message 6`] = `
+Object {
+  "actual": "HTML Output of <ul>:
+ <ul>
+  <li>
+    <User index={1} className=\\"userOne\\" />
+  </li>
+  <li>
+    <User index={2} className=\\"userTwo\\" />
+  </li>
+</ul>",
+}
+`;
+
+exports[`toContainMatchingNodes with a shallow wrapper provides contextual information for the message 7`] = `
+Object {
+  "actual": "HTML Output of <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
+}
+`;
+
+exports[`toContainMatchingNodes with a shallow wrapper provides contextual information for the message 8`] = `
+Object {
+  "actual": "HTML Output of <div>:
+ <div>
+  <ul>
+    <li>
+      <User index={1} className=\\"userOne\\" />
+    </li>
+    <li>
+      <User index={2} className=\\"userTwo\\" />
+    </li>
+  </ul>
+</div>",
+}
+`;
+
+exports[`toContainMatchingNodes with a shallow wrapper returns the proper verbage for "1 .userOne in User" 1`] = `"Expected <span> to contain 1 node matching \\".userOne\\" but 1 was found."`;
+
+exports[`toContainMatchingNodes with a shallow wrapper returns the proper verbage for "1 .userOne" 1`] = `"Expected <div> to not contain 1 node matching \\".userOne\\" but it did."`;
+
+exports[`toContainMatchingNodes with a shallow wrapper returns the proper verbage for "1 .userThree" 1`] = `"Expected <div> to not contain 1 node matching \\".userThree\\" but it did."`;
+
+exports[`toContainMatchingNodes with a shallow wrapper returns the proper verbage for "1 [data-index="value-1"] in User" 1`] = `"Expected <span> to contain 1 node matching \\"[data-index=\\"value-1\\"]\\" but 1 was found."`;
+
+exports[`toContainMatchingNodes with a shallow wrapper returns the proper verbage for "1 [data-index="value-1"]" 1`] = `"Expected <div> to not contain 1 node matching \\"[data-index=\\"value-1\\"]\\" but it did."`;
+
+exports[`toContainMatchingNodes with a shallow wrapper returns the proper verbage for "1 [data-index]" 1`] = `"Expected <div> to not contain 1 node matching \\"[data-index]\\" but it did."`;
+
+exports[`toContainMatchingNodes with a shallow wrapper returns the proper verbage for "2 [data-index] in ul" 1`] = `"Expected <ul> to not contain 2 nodes matching \\"[data-index]\\" but it did."`;
+
+exports[`toContainMatchingNodes with a shallow wrapper returns the proper verbage for "2 [data-index]" 1`] = `"Expected <div> to not contain 2 nodes matching \\"[data-index]\\" but it did."`;

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainReact.test.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainReact.test.js.snap
@@ -3,10 +3,29 @@
 exports[`toContainReact provides contextual information for the message 1`] = `
 Object {
   "actual": "HTML Output of <div>:
- <div><ul><li><User index={1} /></li><li><User index={2} /></li></ul></div>",
+ <div>
+  <ul>
+    <li>
+      <User index={1} />
+    </li>
+    <li>
+      <User index={2} />
+    </li>
+  </ul>
+</div>",
 }
 `;
 
-exports[`toContainReact returns the message with the proper fail verbage 1`] = `"Expected <div> not to contain <span>User 1</span> but it does."`;
+exports[`toContainReact returns the message with the proper fail verbage 1`] = `
+"Expected <div> not to contain <span>
+  User 
+  1
+</span> but it does."
+`;
 
-exports[`toContainReact returns the message with the proper pass verbage 1`] = `"Expected <div> to contain <span>User 1</span> but it was not found."`;
+exports[`toContainReact returns the message with the proper pass verbage 1`] = `
+"Expected <div> to contain <span>
+  User 
+  1
+</span> but it was not found."
+`;

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toHaveClassName.test.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toHaveClassName.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`toHaveClassName mount provides contextual information for the message (mount) 1`] = `
 Object {
-  "actual": "Found node output: <span class=\\"bar baz\\"></span>",
+  "actual": "Found node output: <span className=\\"bar baz\\" />",
 }
 `;
 

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toHaveDisplayName.test.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toHaveDisplayName.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`toHaveDisplayName mount provides contextual information for the message (mount) 1`] = `
 Object {
-  "actual": "<a id=\\"a\\"></a>",
+  "actual": "<a id=\\"a\\" />",
 }
 `;
 
@@ -22,7 +22,13 @@ exports[`toHaveDisplayName mount returns the message with the proper pass verbag
 exports[`toHaveDisplayName mount works on composite functions 1`] = `
 Object {
   "contextualInformation": Object {
-    "actual": "<div><span id=\\"span\\"></span><span></span><a id=\\"a\\"></a></div>",
+    "actual": "<Fixture>
+  <div>
+    <span id=\\"span\\" />
+    <span />
+    <a id=\\"a\\" />
+  </div>
+</Fixture>",
   },
   "message": "Expected <Fixture> to have display name \\"Fixture\\" but it had display name \\"Fixture\\".",
   "negatedMessage": "Expected <Fixture> to not have display name \\"Fixture\\" but it did.",
@@ -33,7 +39,13 @@ Object {
 exports[`toHaveDisplayName mount works on composite functions 2`] = `
 Object {
   "contextualInformation": Object {
-    "actual": "<div><span id=\\"span\\"></span><span></span><a id=\\"a\\"></a></div>",
+    "actual": "<Fixture>
+  <div>
+    <span id=\\"span\\" />
+    <span />
+    <a id=\\"a\\" />
+  </div>
+</Fixture>",
   },
   "message": "Expected <Fixture> to have display name \\"a\\" but it had display name \\"Fixture\\".",
   "negatedMessage": "Expected <Fixture> to not have display name \\"a\\" but it did.",
@@ -63,7 +75,11 @@ exports[`toHaveDisplayName shallow returns the message with the proper pass verb
 exports[`toHaveDisplayName shallow works on composite functions 1`] = `
 Object {
   "contextualInformation": Object {
-    "actual": "<div><span id=\\"span\\" /><span /><a id=\\"a\\" /></div>",
+    "actual": "<div>
+  <span id=\\"span\\" />
+  <span />
+  <a id=\\"a\\" />
+</div>",
   },
   "message": "Expected <div> to have display name \\"Fixture\\" but it had display name \\"div\\".",
   "negatedMessage": "Expected <div> to not have display name \\"Fixture\\" but it did.",
@@ -74,7 +90,11 @@ Object {
 exports[`toHaveDisplayName shallow works on composite functions 2`] = `
 Object {
   "contextualInformation": Object {
-    "actual": "<div><span id=\\"span\\" /><span /><a id=\\"a\\" /></div>",
+    "actual": "<div>
+  <span id=\\"span\\" />
+  <span />
+  <a id=\\"a\\" />
+</div>",
   },
   "message": "Expected <div> to have display name \\"a\\" but it had display name \\"div\\".",
   "negatedMessage": "Expected <div> to not have display name \\"a\\" but it did.",

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toHaveStyle.test.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toHaveStyle.test.js.snap
@@ -10,7 +10,7 @@ Object {
 exports[`toHaveStyle mount provides the right info for if there is no style prop 1`] = `
 Object {
   "contextualInformation": Object {
-    "actual": "<div></div>",
+    "actual": "<div />",
   },
   "message": "Expected <div> component to have a style prop but it did not.",
   "negatedMessage": "Expected <div> component not to have a style prop but it did.",
@@ -21,7 +21,7 @@ Object {
 exports[`toHaveStyle mount provides the right info when a specific key doesn't exist 1`] = `
 Object {
   "contextualInformation": Object {
-    "actual": "<div style=\\"width: 0px;\\"></div>",
+    "actual": "<div style={{...}} />",
   },
   "message": "Expected <div> component to have a style keys of \\"height\\" but it did not.",
   "negatedMessage": "Expected <div> component not to have a style key of \\"height\\" but it did.",

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toHaveValue.test.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toHaveValue.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`toHaveValue mount provides contextual information for the message (mount) 1`] = `
 Object {
-  "actual": "<input value=\\"test\\">",
+  "actual": "<input defaultValue=\\"test\\" />",
 }
 `;
 

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toMatchSelector.test.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toMatchSelector.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`toMatchSelector mount provides contextual information for the message (mount) 1`] = `
 Object {
-  "actual": "<span id=\\"child\\" class=\\"foo\\"></span>",
+  "actual": "<span id=\\"child\\" className=\\"foo\\" />",
 }
 `;
 

--- a/packages/enzyme-matchers/src/assertions/__tests__/toContainExactlyOneMatchingNode.test.js
+++ b/packages/enzyme-matchers/src/assertions/__tests__/toContainExactlyOneMatchingNode.test.js
@@ -1,10 +1,10 @@
 const PropTypes = require('prop-types');
 const getNodeName = require('../../utils/name');
-const toContainExactlyOneMatchingElement = require('../toContainExactlyOneMatchingElement');
+const toContainExactlyOneMatchingNode = require('../toContainExactlyOneMatchingNode');
 
 function User(props) {
   return (
-    <span>
+    <span className={props.className}>
       User <span data-index={`value-${props.index}`}>{props.index}</span>
     </span>
   );
@@ -12,6 +12,7 @@ function User(props) {
 
 User.propTypes = {
   index: PropTypes.number.isRequired,
+  className: PropTypes.string,
 };
 
 function Fixture() {
@@ -29,23 +30,26 @@ function Fixture() {
   );
 }
 
-describe('toContainExactlyOneMatchingElement', () => {
+describe('toContainExactlyOneMatchingNode', () => {
   [shallow, mount].forEach(renderer => {
     describe(`with a ${renderer.name} wrapper`, () => {
       const wrapper = renderer(<Fixture />);
+      const firstUserWrapper =
+        renderer === shallow
+          ? wrapper.find('User').first().shallow()
+          : wrapper.find('User');
       const argsToTest = [
-        [wrapper, '.userOne', true],
-        [wrapper, 'User', false],
-        [wrapper, '[index=1]', true],
-        [wrapper, '[index]', false],
-        [wrapper.find('ul'), '[index]', false],
-        [wrapper.find('User'), '[index=1]', true],
-        [wrapper, '.userThree', false],
+        [wrapper, '.userOne', renderer === mount],
         [wrapper, '[data-index="value-1"]', renderer === mount],
+        [wrapper, '[data-index]', false],
+        [firstUserWrapper, '[data-index="value-1"]', true],
+        [firstUserWrapper, '.userOne', true],
+        [wrapper, '.userThree', false],
+        [wrapper, '[data-index]', false],
       ];
 
       argsToTest.forEach(([currentWrapper, selector, expectedResult]) => {
-        const result = toContainExactlyOneMatchingElement(
+        const result = toContainExactlyOneMatchingNode(
           currentWrapper,
           selector
         );

--- a/packages/enzyme-matchers/src/assertions/__tests__/toContainMatchingElements.test.js
+++ b/packages/enzyme-matchers/src/assertions/__tests__/toContainMatchingElements.test.js
@@ -1,11 +1,11 @@
 const PropTypes = require('prop-types');
-
+const getNodeName = require('../../utils/name');
 const toContainMatchingElements = require('../toContainMatchingElements');
 
 function User(props) {
   return (
     <span className={props.className}>
-      User {props.index}
+      User <span data-index={`value-${props.index}`}>{props.index}</span>
     </span>
   );
 }
@@ -31,45 +31,74 @@ function Fixture() {
 }
 
 describe('toContainMatchingElements', () => {
-  const wrapper = shallow(<Fixture />);
-  const truthyResults = [
-    toContainMatchingElements(wrapper, 2, 'User'),
-    toContainMatchingElements(wrapper, 1, '[index=1]'),
-    toContainMatchingElements(wrapper, 2, '[index]'),
-    toContainMatchingElements(wrapper.find('ul'), 2, '[index]'),
-    toContainMatchingElements(wrapper.find('User'), 1, '[index=1]'),
-  ];
-  const falsyResults = [
-    toContainMatchingElements(wrapper, 3, 'User'),
-    toContainMatchingElements(wrapper, 1, '.userThree'),
-    toContainMatchingElements(wrapper, 1, '[index]'),
-    toContainMatchingElements(wrapper.find('ul'), 3, '[index]'),
-  ];
+  [shallow, mount].forEach(renderer => {
+    describe(`with a ${renderer.name} wrapper`, () => {
+      const wrapper = renderer(<Fixture />);
+      const argsToTest = [
+        ['2 User', wrapper, 2, 'User', true],
+        ['1 [index=1]', wrapper, 1, '[index=1]', true],
+        ['2 [index]', wrapper, 2, '[index]', true],
+        ['2 [index] in ul', wrapper.find('ul'), 2, '[index]', true],
+        ['1 [index=1] in User', wrapper.find('User'), 1, '[index=1]', true],
+        ['3 User', wrapper, 3, 'User', false],
+        ['1 .userThree', wrapper, 1, '.userThree', false],
+        ['1 [index]', wrapper, 1, '[index]', false],
+        ['3 [index] in ul', wrapper.find('ul'), 3, '[index]', false],
+        ['1 [data-index]', wrapper, 1, '[data-index]', false],
+        ...(renderer === shallow
+          ? [
+              ['1 .userOne', wrapper, 1, '.userOne', true],
+              ['0 [data-index]', wrapper, 0, '[data-index]', true],
+              [
+                '1 [data-index="value-1"]',
+                wrapper,
+                1,
+                '[data-index="value-1"]',
+                false,
+              ],
+            ]
+          : []),
+        ...(renderer === mount
+          ? [
+              ['2 .userOne', wrapper, 2, '.userOne', true],
+              ['2 [data-index]', wrapper, 2, '[data-index]', true],
+              [
+                '1 [data-index="value-1"]',
+                wrapper,
+                1,
+                '[data-index="value-1"]',
+                true,
+              ],
+            ]
+          : []),
+      ];
 
-  it('returns the pass flag properly', () => {
-    truthyResults.forEach(truthyResult => {
-      expect(truthyResult.pass).toBe(true);
-    });
-    falsyResults.forEach(falsyResult => {
-      expect(falsyResult.pass).toBe(false);
-    });
-  });
+      argsToTest.forEach(
+        ([description, currentWrapper, count, selector, expectedResult]) => {
+          const result = toContainMatchingElements(
+            currentWrapper,
+            count,
+            selector
+          );
+          it(`returns ${expectedResult} for "${selector}" in <${getNodeName(
+            currentWrapper
+          )}>`, () => {
+            expect(result.pass).toBe(expectedResult);
+          });
 
-  it('returns the message with the proper pass verbage', () => {
-    truthyResults.forEach(truthyResult => {
-      expect(truthyResult.message).toMatchSnapshot();
-    });
-  });
+          it(`returns the proper verbage for "${description}"`, () => {
+            if (expectedResult) {
+              expect(result.message).toMatchSnapshot();
+            } else {
+              expect(result.negatedMessage).toMatchSnapshot();
+            }
+          });
 
-  it('returns the message with the proper fail verbage', () => {
-    falsyResults.forEach(falsyResult => {
-      expect(falsyResult.negatedMessage).toMatchSnapshot();
-    });
-  });
-
-  it('provides contextual information for the message', () => {
-    truthyResults.forEach(truthyResult => {
-      expect(truthyResult.contextualInformation).toMatchSnapshot();
+          it('provides contextual information for the message', () => {
+            expect(result.contextualInformation).toMatchSnapshot();
+          });
+        }
+      );
     });
   });
 });

--- a/packages/enzyme-matchers/src/assertions/__tests__/toContainMatchingNode.test.js
+++ b/packages/enzyme-matchers/src/assertions/__tests__/toContainMatchingNode.test.js
@@ -1,10 +1,10 @@
 const PropTypes = require('prop-types');
 const getNodeName = require('../../utils/name');
-const toContainExactlyOneMatchingElement = require('../toContainExactlyOneMatchingElement');
+const toContainMatchingNode = require('../toContainMatchingNode');
 
 function User(props) {
   return (
-    <span>
+    <span className={props.className}>
       User <span data-index={`value-${props.index}`}>{props.index}</span>
     </span>
   );
@@ -12,6 +12,7 @@ function User(props) {
 
 User.propTypes = {
   index: PropTypes.number.isRequired,
+  className: PropTypes.string,
 };
 
 function Fixture() {
@@ -29,26 +30,24 @@ function Fixture() {
   );
 }
 
-describe('toContainExactlyOneMatchingElement', () => {
+describe('toContainMatchingNode', () => {
   [shallow, mount].forEach(renderer => {
     describe(`with a ${renderer.name} wrapper`, () => {
       const wrapper = renderer(<Fixture />);
+      const firstUserWrapper =
+        renderer === shallow
+          ? wrapper.find('User').first().shallow()
+          : wrapper.find('User');
       const argsToTest = [
-        [wrapper, '.userOne', true],
-        [wrapper, 'User', false],
-        [wrapper, '[index=1]', true],
-        [wrapper, '[index]', false],
-        [wrapper.find('ul'), '[index]', false],
-        [wrapper.find('User'), '[index=1]', true],
-        [wrapper, '.userThree', false],
+        [wrapper, '.userOne', renderer === mount],
         [wrapper, '[data-index="value-1"]', renderer === mount],
+        [wrapper, '[data-index]', renderer === mount],
+        [firstUserWrapper, '[data-index="value-1"]', true],
+        [firstUserWrapper, '.userOne', true],
       ];
 
       argsToTest.forEach(([currentWrapper, selector, expectedResult]) => {
-        const result = toContainExactlyOneMatchingElement(
-          currentWrapper,
-          selector
-        );
+        const result = toContainMatchingNode(currentWrapper, selector);
         it(`returns ${expectedResult} for "${selector}" in <${getNodeName(
           currentWrapper
         )}>`, () => {

--- a/packages/enzyme-matchers/src/assertions/__tests__/toContainMatchingNodes.test.js
+++ b/packages/enzyme-matchers/src/assertions/__tests__/toContainMatchingNodes.test.js
@@ -1,0 +1,139 @@
+const PropTypes = require('prop-types');
+const getNodeName = require('../../utils/name');
+const toContainMatchingNodes = require('../toContainMatchingNodes');
+
+function User(props) {
+  return (
+    <span className={props.className}>
+      User <span data-index={`value-${props.index}`}>{props.index}</span>
+    </span>
+  );
+}
+
+User.propTypes = {
+  index: PropTypes.number.isRequired,
+  className: PropTypes.string,
+};
+
+function Fixture() {
+  return (
+    <div>
+      <ul>
+        <li>
+          <User index={1} className="userOne" />
+        </li>
+        <li>
+          <User index={2} className="userTwo" />
+        </li>
+      </ul>
+    </div>
+  );
+}
+
+describe('toContainMatchingNodes', () => {
+  [shallow, mount].forEach(renderer => {
+    describe(`with a ${renderer.name} wrapper`, () => {
+      const wrapper = renderer(<Fixture />);
+      const firstUserWrapper =
+        renderer === shallow
+          ? wrapper.find('User').first().shallow()
+          : wrapper.find('User');
+      const argsToTest = [
+        ['1 .userOne', wrapper, 1, '.userOne', renderer === mount],
+        [
+          '1 [data-index="value-1"]',
+          wrapper,
+          1,
+          '[data-index="value-1"]',
+          renderer === mount,
+        ],
+        ['2 [data-index]', wrapper, 2, '[data-index]', renderer === mount],
+        [
+          '1 [data-index="value-1"] in User',
+          firstUserWrapper,
+          1,
+          '[data-index="value-1"]',
+          true,
+        ],
+        ['1 .userOne in User', firstUserWrapper, 1, '.userOne', true],
+        [
+          '2 [data-index] in ul',
+          wrapper.find('ul'),
+          2,
+          '[data-index]',
+          renderer === mount,
+        ],
+        ['1 .userThree', wrapper, 1, '.userThree', false],
+        ['1 [data-index]', wrapper, 1, '[data-index]', false],
+      ];
+
+      argsToTest.forEach(
+        ([description, currentWrapper, count, selector, expectedResult]) => {
+          const result = toContainMatchingNodes(
+            currentWrapper,
+            count,
+            selector
+          );
+          it(`returns ${expectedResult} for "${selector}" in <${getNodeName(
+            currentWrapper
+          )}>`, () => {
+            expect(result.pass).toBe(expectedResult);
+          });
+
+          it(`returns the proper verbage for "${description}"`, () => {
+            if (expectedResult) {
+              expect(result.message).toMatchSnapshot();
+            } else {
+              expect(result.negatedMessage).toMatchSnapshot();
+            }
+          });
+
+          it('provides contextual information for the message', () => {
+            expect(result.contextualInformation).toMatchSnapshot();
+          });
+        }
+      );
+    });
+  });
+});
+
+describe('toContainMatchingNodes', () => {
+  const wrapper = mount(<Fixture />);
+  const argsToTest = [
+    ['1 .userOne', wrapper, 1, '.userOne', true],
+    ['1 [data-index="value-1"]', wrapper, 1, '[data-index="value-1"]', true],
+    ['2 [data-index]', wrapper, 2, '[data-index]', true],
+    ['2 [data-index] in ul', wrapper.find('ul'), 2, '[data-index]', true],
+    [
+      '1 [data-index="value-1"] in User',
+      wrapper.find('User'),
+      1,
+      '[data-index="value-1"]',
+      true,
+    ],
+    ['1 .userThree', wrapper, 1, '.userThree', false],
+    ['1 [data-index]', wrapper, 1, '[data-index]', false],
+    ['3 [data-index] in ul', wrapper.find('ul'), 3, '[data-index]', false],
+  ];
+
+  argsToTest.forEach(
+    ([description, currentWrapper, count, selector, expectedResult]) => {
+      const result = toContainMatchingNodes(currentWrapper, count, selector);
+      it(`returns ${expectedResult} for "${description}"`, () => {
+        expect(result.pass).toBe(expectedResult);
+      });
+
+      it(`returns the proper verbage for "${description}"`, () => {
+        if (expectedResult) {
+          expect(result.message).toMatchSnapshot();
+        } else {
+          expect(result.negatedMessage).toMatchSnapshot();
+        }
+      });
+
+      it('provides contextual information for the message', () => {
+        expect(result.contextualInformation).toMatchSnapshot();
+      });
+    }
+  );
+});

--- a/packages/enzyme-matchers/src/assertions/toContainExactlyOneMatchingNode.js
+++ b/packages/enzyme-matchers/src/assertions/toContainExactlyOneMatchingNode.js
@@ -1,0 +1,19 @@
+/**
+ * This source code is licensed under the MIT-style license found in the
+ * LICENSE file in the root directory of this source tree. *
+ *
+ * @providesModule toContainExactlyOneMatchingNode
+ * @flow
+ */
+
+import type { EnzymeObject, Matcher } from '../types';
+import toContainMatchingNodes from './toContainMatchingNodes';
+
+function toContainExactlyOneMatchingNode(
+  enzymeWrapper: EnzymeObject,
+  selector: string
+): Matcher {
+  return toContainMatchingNodes(enzymeWrapper, 1, selector);
+}
+
+export default toContainExactlyOneMatchingNode;

--- a/packages/enzyme-matchers/src/assertions/toContainMatchingElement.js
+++ b/packages/enzyme-matchers/src/assertions/toContainMatchingElement.js
@@ -28,7 +28,7 @@ function toContainMatchingElement(
       `Expected <${nodeName}> to not contain an element matching ` +
       `"${getDisplayName(selector)}" but it did.`,
     contextualInformation: {
-      actual: `HTML Output of <${nodeName}>:\n ${html(enzymeWrapper)}`,
+      actual: `Element tree for <${nodeName}>:\n ${html(enzymeWrapper)}`,
     },
   };
 }

--- a/packages/enzyme-matchers/src/assertions/toContainMatchingElements.js
+++ b/packages/enzyme-matchers/src/assertions/toContainMatchingElements.js
@@ -34,7 +34,7 @@ function toContainMatchingElements(
       ? ''
       : 's'} matching "${getDisplayName(selector)}" but it did.`,
     contextualInformation: {
-      actual: `HTML Output of <${nodeName}>:\n ${html(enzymeWrapper)}`,
+      actual: `Element tree for <${nodeName}>:\n ${html(enzymeWrapper)}`,
     },
   };
 }

--- a/packages/enzyme-matchers/src/assertions/toContainMatchingNode.js
+++ b/packages/enzyme-matchers/src/assertions/toContainMatchingNode.js
@@ -1,0 +1,36 @@
+/**
+ * This source code is licensed under the MIT-style license found in the
+ * LICENSE file in the root directory of this source tree. *
+ *
+ * @providesModule toContainMatchingElement
+ * @flow
+ */
+
+import type { EnzymeObject, Matcher } from '../types';
+import html from '../utils/html';
+import getDisplayName from '../utils/displayName';
+import getNodeName from '../utils/name';
+
+function toContainMatchingNode(
+  enzymeWrapper: EnzymeObject,
+  selector: string
+): Matcher {
+  const matches = enzymeWrapper.find(selector).hostNodes();
+  const pass = matches.length > 0;
+  const nodeName = getNodeName(enzymeWrapper);
+
+  return {
+    pass,
+    message:
+      `Expected <${nodeName}> to contain at least one node matching ` +
+      `"${getDisplayName(selector)}" but none were found.`,
+    negatedMessage:
+      `Expected <${nodeName}> to not contain a node matching ` +
+      `"${getDisplayName(selector)}" but it did.`,
+    contextualInformation: {
+      actual: `HTML Output of <${nodeName}>:\n ${html(enzymeWrapper, true)}`,
+    },
+  };
+}
+
+export default toContainMatchingNode;

--- a/packages/enzyme-matchers/src/assertions/toContainMatchingNodes.js
+++ b/packages/enzyme-matchers/src/assertions/toContainMatchingNodes.js
@@ -1,0 +1,42 @@
+/**
+ * This source code is licensed under the MIT-style license found in the
+ * LICENSE file in the root directory of this source tree. *
+ *
+ * @providesModule toContainMatchingNodes
+ * @flow
+ */
+
+import type { EnzymeObject, Matcher } from '../types';
+import html from '../utils/html';
+import getDisplayName from '../utils/displayName';
+import getNodeName from '../utils/name';
+
+function toContainMatchingNodes(
+  enzymeWrapper: EnzymeObject,
+  n: number,
+  selector: string
+): Matcher {
+  const matches = enzymeWrapper.find(selector).hostNodes();
+  const pass = matches.length === n;
+  const nodeName = getNodeName(enzymeWrapper);
+
+  return {
+    pass,
+    message:
+      `Expected <${nodeName}> to contain ${n} node${n === 1
+        ? ''
+        : 's'} matching ` +
+      `"${getDisplayName(selector)}" but ${matches.length} ${matches.length ===
+      1
+        ? 'was'
+        : 'were'} found.`,
+    negatedMessage: `Expected <${nodeName}> to not contain ${n} node${n === 1
+      ? ''
+      : 's'} matching "${getDisplayName(selector)}" but it did.`,
+    contextualInformation: {
+      actual: `HTML Output of <${nodeName}>:\n ${html(enzymeWrapper, true)}`,
+    },
+  };
+}
+
+export default toContainMatchingNodes;

--- a/packages/enzyme-matchers/src/utils/__tests__/html.test.js
+++ b/packages/enzyme-matchers/src/utils/__tests__/html.test.js
@@ -3,7 +3,7 @@ const html = require('../html');
 describe('html', () => {
   const inputStrings = {
     shallow: '<input />',
-    mount: '<input>',
+    mount: '<input />',
   };
 
   [shallow, mount].forEach(builder => {
@@ -53,7 +53,7 @@ describe('html', () => {
       const wrapper = shallow(<Bar />);
       // simulate platforms where function.name is undefined
       wrapper.constructor = { toString: () => 'function ShallowWrapper() {}' };
-      expect(html(wrapper)).toBe('<div><Foo /></div>');
+      expect(html(wrapper)).toBe('<div>\n  <Foo />\n</div>');
     });
   });
 });

--- a/packages/enzyme-matchers/src/utils/html.js
+++ b/packages/enzyme-matchers/src/utils/html.js
@@ -39,19 +39,22 @@ function mapWrappersHTML(wrapper: EnzymeObject): Array<string> {
   });
 }
 
-export default function printHTMLForWrapper(wrapper: EnzymeObject): string {
+export default function printHTMLForWrapper(
+  wrapper: EnzymeObject,
+  hostNodesOnly?: boolean
+): string {
   switch (wrapper.getElements().length) {
     case 0: {
       return '[empty set]';
     }
     case 1: {
       if (isShallowWrapper(wrapper)) {
-        // This is used to clean up in any awkward spacing in the debug output.
-        // <div>  <Foo /></div> => <div><Foo /></div>
-        return wrapper.debug().replace(/\n(\s*)/g, '');
+        return wrapper.debug();
       }
-
-      return wrapper.html();
+      if (hostNodesOnly) {
+        return wrapper.html();
+      }
+      return wrapper.debug();
     }
     default: {
       const nodes = mapWrappersHTML(wrapper).reduce(

--- a/packages/enzyme-matchers/src/utils/name.js
+++ b/packages/enzyme-matchers/src/utils/name.js
@@ -67,7 +67,7 @@ export default function getNameFromArbitraryWrapper(wrapper: Object): string {
 
       // determine if we have a mixed list of nodes or not
       wrapper.getElements().forEach(node => {
-        const name: string = getNameFromRoot(node);
+        const name = node ? getNameFromRoot(node) : `${node}`;
         nodeTypeMap[name] = (nodeTypeMap[name] || 0) + 1;
       });
 

--- a/packages/jasmine-enzyme/README.md
+++ b/packages/jasmine-enzyme/README.md
@@ -49,6 +49,9 @@ describe('test', () => {
 * [toBeDisabled()](#tobedisabled)
 * [toBeEmptyRender()](#tobeemptyrender)
 * [toExist()](#toexist)
+* [toContainMatchingNode()](#tocontainmatchingnode)
+* [toContainMatchingNodes()](#tocontainmatchingnodes)
+* [toContainExactlyOneMatchingNode()](#tocontainexactlyonematchingnode)
 * [toContainMatchingElement()](#tocontainmatchingelement)
 * [toContainMatchingElements()](#tocontainmatchingelements)
 * [toContainExactlyOneMatchingElement()](#tocontainexactlyonematchingelement)
@@ -79,7 +82,7 @@ Ways to use this API:
 expect().toBeChecked();
 ```
 
-Assert that the given wrapper is checked:
+Assert that the given wrapper is checked.
 
 ```js
 import React from 'react'
@@ -113,7 +116,7 @@ Ways to use this API:
 expect().toBeDisabled();
 ```
 
-Assert that the given wrapper is disabled:
+Assert that the given wrapper is disabled.
 
 ```js
 import React from 'react'
@@ -146,7 +149,7 @@ Ways to use this API:
 expect().toBeEmptyRender();
 ```
 
-Assert that the given wrapper has an empty render (`null` or `false`):
+Assert that the given wrapper has an empty render (`null` or `false`).
 
 ```js
 function EmptyRenderFixture() {
@@ -197,6 +200,153 @@ expect(wrapper.find('span')).toExist();
 expect(wrapper.find('ul')).not.toExist();
 ```
 
+#### `toContainMatchingNode()`
+
+| render | mount | shallow |
+| -------|-------|-------- |
+| no     | yes   | yes     |
+
+Ways to use this API:
+
+```js
+expect().toContainMatchingNode('.foo');
+```
+
+Assert that the given wrapper contains at least one matching host node for the given selector. Only matches against host nodes. When using react-dom, host nodes are HTML elements rather than custom React components, e.g. `<div>` versus `<MyComponent>`.
+
+```js
+function User(props) {
+  return (
+    <span className={props.className}>
+      User {props.index}
+    </span>
+  );
+}
+
+User.propTypes = {
+  index: PropTypes.number.isRequired,
+  className: PropTypes.string,
+};
+
+function Fixture() {
+  return (
+    <div>
+      <ul>
+        <li>
+          <User index={1} className="userOne" />
+        </li>
+        <li>
+          <User index={2} className="userTwo" />
+        </li>
+      </ul>
+    </div>
+  );
+}
+
+const wrapper = mount(<Fixture />); // mount/render/shallow when applicable
+
+expect(wrapper).toContainMatchingNode('.userOne');
+expect(wrapper).not.toContainMatchingNode('.userThree');
+```
+
+#### `toContainMatchingNodes()`
+
+| render | mount | shallow |
+| -------|-------|-------- |
+| no     | yes   | yes     |
+
+Ways to use this API:
+
+```js
+expect().toContainMatchingNodes(2, '.foo');
+```
+
+Assert that the given wrapper contains a given number of matching host nodes for the given selector. Only matches against host nodes. When using react-dom, host nodes are HTML elements rather than custom React components, e.g. `<div>` versus `<MyComponent>`.
+
+```js
+function User(props) {
+  return (
+    <span className={`user ${props.className}`}>
+      User {props.index}
+    </span>
+  );
+}
+
+User.propTypes = {
+  index: PropTypes.number.isRequired,
+  className: PropTypes.string,
+};
+
+function Fixture() {
+  return (
+    <div>
+      <ul>
+        <li>
+          <User index={1} className="userOne" />
+        </li>
+        <li>
+          <User index={2} className="userTwo" />
+        </li>
+      </ul>
+    </div>
+  );
+}
+
+const wrapper = mount(<Fixture />); // mount/render/shallow when applicable
+
+expect(wrapper).toContainMatchingNodes(2, '.user');
+expect(wrapper).not.toContainMatchingNodes(2, '.userTwo');
+```
+
+#### `toContainExactlyOneMatchingNode()`
+
+| render | mount | shallow |
+| -------|-------|-------- |
+| no     | yes   | yes     |
+
+Ways to use this API:
+
+```js
+expect().toContainExactlyOneMatchingNode('.foo');
+```
+
+Assert that the given wrapper contains exactly one matching node for the given selector. Only matches against host nodes. When using react-dom, host nodes are HTML elements rather than custom React components, e.g. `<div>` versus `<MyComponent>`.
+
+```js
+function User(props) {
+  return (
+    <span className={`user ${props.className}`}>
+      User {props.index}
+    </span>
+  );
+}
+
+User.propTypes = {
+  index: PropTypes.number.isRequired,
+  className: PropTypes.string,
+};
+
+function Fixture() {
+  return (
+    <div>
+      <ul>
+        <li>
+          <User index={1} className="userOne" />
+        </li>
+        <li>
+          <User index={2} className="userTwo" />
+        </li>
+      </ul>
+    </div>
+  );
+}
+
+const wrapper = mount(<Fixture />); // mount/render/shallow when applicable
+
+expect(wrapper).toContainExactlyOneMatchingNode('.userOne');
+expect(wrapper).not.toContainExactlyOneMatchingNode('.user');
+```
+
 #### `toContainMatchingElement()`
 
 | render | mount | shallow |
@@ -209,7 +359,7 @@ Ways to use this API:
 expect().toContainMatchingElement('.foo');
 ```
 
-Assert that the given wrapper contains at least one match for the given selector:
+Assert that the given wrapper contains at least one matching element for the given selector. Matches against both host nodes like `<div>` and custom React components like `<MyComponent>`.
 
 ```js
 function User(props) {
@@ -258,7 +408,7 @@ Ways to use this API:
 expect().toContainMatchingElements(2, '.foo');
 ```
 
-Assert that the given wrapper contains a given number of matches for the given selector:
+Assert that the given wrapper contains a given number of matches for the given selector. Matches against both host nodes like `<div>` and custom React components like `<MyComponent>`.
 
 ```js
 function User(props) {
@@ -292,8 +442,12 @@ function Fixture() {
 const wrapper = mount(<Fixture />); // mount/render/shallow when applicable
 
 expect(wrapper).toContainMatchingElements(2, 'User');
-expect(wrapper).not.toContainMatchingElements(2, '.userTwo');
+expect(wrapper).toContainMatchingElements(2, 'span.user');
+expect(wrapper).not.toContainMatchingElements(2, 'span.userTwo');
 ```
+
+**Note:** The selector in the first assertion above is qualified using the tag name `span`. If it was not, `toContainMatchingElements` would fail because `wrapper.find('.user')` matches twice for both `User.user` and `span.user`, for a total of 4 matches. To only match host (DOM) nodes, use [`.toContainMatchingNodes(2, '.user')`](#tocontainmatchingnodes).
+
 
 #### `toContainExactlyOneMatchingElement()`
 
@@ -307,7 +461,7 @@ Ways to use this API:
 expect().toContainExactlyOneMatchingElement('.foo');
 ```
 
-Assert that the given wrapper contains exactly one match for the given selector:
+Assert that the given wrapper contains exactly one match for the given selector. Matches against both host nodes like `<div>` and custom React components like `<MyComponent>`.
 
 ```js
 function User(props) {
@@ -340,9 +494,11 @@ function Fixture() {
 
 const wrapper = mount(<Fixture />); // mount/render/shallow when applicable
 
-expect(wrapper).toContainExactlyOneMatchingElement('.userOne');
+expect(wrapper).toContainExactlyOneMatchingElement('span.userOne');
 expect(wrapper).not.toContainExactlyOneMatchingElement('User');
 ```
+
+**Note:** The selector in the first assertion above is qualified using the tag name `span`. If it was not, `toContainExactlyOneMatchingElement` would fail because `wrapper.find('.userOne')` matches for both `User.userOne` and `span.userOne`. To only match host (DOM) nodes, use [`.toContainExactlyOneMatchingNode('.userOne')`](#tocontainexactlyonematchingnode).
 
 #### `toContainReact()`
 
@@ -356,7 +512,7 @@ Ways to use this API:
 expect().toContainReact(<div>foo</div>);
 ```
 
-Assert that the given wrapper contains the provided react instance:
+Assert that the given wrapper contains the provided react instance.
 
 ```js
 class User extends React.Component {
@@ -402,7 +558,7 @@ Ways to use this API:
 expect().toHaveClassName('foo');
 ```
 
-Assert that the given wrapper has the provided className:
+Assert that the given wrapper has the provided className.
 
 ```js
 function Fixture() {
@@ -435,7 +591,7 @@ Ways to use this API:
 expect().toHaveDisplayName('div');
 ```
 
-Assert that the wrapper is of a certain tag type:
+Assert that the wrapper is of a certain tag type.
 
 ```js
 function Fixture() {
@@ -465,7 +621,7 @@ expect().toHaveHTML('<div>html</div>');
 ```
 
 
-Assert that the given wrapper has the provided html:
+Assert that the given wrapper has the provided html.
 
 > **Note** Quotations are normalized.
 
@@ -499,7 +655,7 @@ expect().toHaveProp('foo');
 expect().toHaveProp({foo: 'value'});
 ```
 
-Assert that the given wrapper has the provided propKey and associated value if specified:
+Assert that the given wrapper has the provided propKey and associated value if specified.
 
 ```js
 function User() { ... }
@@ -542,7 +698,7 @@ Ways to use this API:
 expect().toHaveRef('foo');
 ```
 
-Assert that the mounted wrapper has the provided ref:
+Assert that the mounted wrapper has the provided ref.
 
 ```js
 class Fixture extends React.Component {
@@ -575,7 +731,7 @@ expect().toHaveState('foo', 'bar');
 expect().toHaveState({ foo: 'bar' });
 ```
 
-Assert that the component has the provided stateKey and optional value if specified:
+Assert that the component has the provided stateKey and optional value if specified.
 
 ```js
 class Fixture extends React.Component {
@@ -614,7 +770,7 @@ expect().toHaveStyle('height', '100%');
 expect().toHaveStyle({ height: '100%' });
 ```
 
-Assert that the component has style of the provided key and value:
+Assert that the component has style of the provided key and value.
 
 ```js
 function Fixture() {
@@ -686,7 +842,7 @@ Ways to use this API:
 expect().toIncludeText('bar');
 ```
 
-Assert that the wrapper includes the provided text:
+Assert that the wrapper includes the provided text.
 
 ```js
 function Fixture() {
@@ -715,7 +871,7 @@ Ways to use this API:
 expect().toHaveValue('bar');
 ```
 
-Assert that the given wrapper has the provided `value`:
+Assert that the given wrapper has the provided `value`.
 
 ```js
 function Fixture() {
@@ -783,7 +939,7 @@ Ways to use this API:
 expect().toMatchSelector('.foo');
 ```
 
-Assert that the wrapper matches the provided `selector`:
+Assert that the wrapper matches the provided `selector`.
 
 ```js
 function Fixture() {

--- a/packages/jest-enzyme/README.md
+++ b/packages/jest-enzyme/README.md
@@ -33,6 +33,9 @@ If you prefer not to use the environment, you can also do this:
 * [toBeDisabled()](#tobedisabled)
 * [toBeEmptyRender()](#tobeemptyrender)
 * [toExist()](#toexist)
+* [toContainMatchingNode()](#tocontainmatchingnode)
+* [toContainMatchingNodes()](#tocontainmatchingnodes)
+* [toContainExactlyOneMatchingNode()](#tocontainexactlyonematchingnode)
 * [toContainMatchingElement()](#tocontainmatchingelement)
 * [toContainMatchingElements()](#tocontainmatchingelements)
 * [toContainExactlyOneMatchingElement()](#tocontainexactlyonematchingelement)
@@ -63,7 +66,7 @@ Ways to use this API:
 expect().toBeChecked();
 ```
 
-Assert that the given wrapper is checked:
+Assert that the given wrapper is checked.
 
 ```js
 import React from 'react'
@@ -97,7 +100,7 @@ Ways to use this API:
 expect().toBeDisabled();
 ```
 
-Assert that the given wrapper is disabled:
+Assert that the given wrapper is disabled.
 
 ```js
 import React from 'react'
@@ -130,7 +133,7 @@ Ways to use this API:
 expect().toBeEmptyRender();
 ```
 
-Assert that the given wrapper has an empty render (`null` or `false`):
+Assert that the given wrapper has an empty render (`null` or `false`).
 
 ```js
 function EmptyRenderFixture() {
@@ -181,6 +184,153 @@ expect(wrapper.find('span')).toExist();
 expect(wrapper.find('ul')).not.toExist();
 ```
 
+#### `toContainMatchingNode()`
+
+| render | mount | shallow |
+| -------|-------|-------- |
+| no     | yes   | yes     |
+
+Ways to use this API:
+
+```js
+expect().toContainMatchingNode('.foo');
+```
+
+Assert that the given wrapper contains at least one matching host node for the given selector. Only matches against host nodes. When using react-dom, host nodes are HTML elements rather than custom React components, e.g. `<div>` versus `<MyComponent>`.
+
+```js
+function User(props) {
+  return (
+    <span className={props.className}>
+      User {props.index}
+    </span>
+  );
+}
+
+User.propTypes = {
+  index: PropTypes.number.isRequired,
+  className: PropTypes.string,
+};
+
+function Fixture() {
+  return (
+    <div>
+      <ul>
+        <li>
+          <User index={1} className="userOne" />
+        </li>
+        <li>
+          <User index={2} className="userTwo" />
+        </li>
+      </ul>
+    </div>
+  );
+}
+
+const wrapper = mount(<Fixture />); // mount/render/shallow when applicable
+
+expect(wrapper).toContainMatchingNode('.userOne');
+expect(wrapper).not.toContainMatchingNode('.userThree');
+```
+
+#### `toContainMatchingNodes()`
+
+| render | mount | shallow |
+| -------|-------|-------- |
+| no     | yes   | yes     |
+
+Ways to use this API:
+
+```js
+expect().toContainMatchingNodes(2, '.foo');
+```
+
+Assert that the given wrapper contains a given number of matching host nodes for the given selector. Only matches against host nodes. When using react-dom, host nodes are HTML elements rather than custom React components, e.g. `<div>` versus `<MyComponent>`.
+
+```js
+function User(props) {
+  return (
+    <span className={`user ${props.className}`}>
+      User {props.index}
+    </span>
+  );
+}
+
+User.propTypes = {
+  index: PropTypes.number.isRequired,
+  className: PropTypes.string,
+};
+
+function Fixture() {
+  return (
+    <div>
+      <ul>
+        <li>
+          <User index={1} className="userOne" />
+        </li>
+        <li>
+          <User index={2} className="userTwo" />
+        </li>
+      </ul>
+    </div>
+  );
+}
+
+const wrapper = mount(<Fixture />); // mount/render/shallow when applicable
+
+expect(wrapper).toContainMatchingNodes(2, '.user');
+expect(wrapper).not.toContainMatchingNodes(2, '.userTwo');
+```
+
+#### `toContainExactlyOneMatchingNode()`
+
+| render | mount | shallow |
+| -------|-------|-------- |
+| no     | yes   | yes     |
+
+Ways to use this API:
+
+```js
+expect().toContainExactlyOneMatchingNode('.foo');
+```
+
+Assert that the given wrapper contains exactly one matching node for the given selector. Only matches against host nodes. When using react-dom, host nodes are HTML elements rather than custom React components, e.g. `<div>` versus `<MyComponent>`.
+
+```js
+function User(props) {
+  return (
+    <span className={`user ${props.className}`}>
+      User {props.index}
+    </span>
+  );
+}
+
+User.propTypes = {
+  index: PropTypes.number.isRequired,
+  className: PropTypes.string,
+};
+
+function Fixture() {
+  return (
+    <div>
+      <ul>
+        <li>
+          <User index={1} className="userOne" />
+        </li>
+        <li>
+          <User index={2} className="userTwo" />
+        </li>
+      </ul>
+    </div>
+  );
+}
+
+const wrapper = mount(<Fixture />); // mount/render/shallow when applicable
+
+expect(wrapper).toContainExactlyOneMatchingNode('.userOne');
+expect(wrapper).not.toContainExactlyOneMatchingNode('.user');
+```
+
 #### `toContainMatchingElement()`
 
 | render | mount | shallow |
@@ -193,7 +343,7 @@ Ways to use this API:
 expect().toContainMatchingElement('.foo');
 ```
 
-Assert that the given wrapper contains at least one match for the given selector:
+Assert that the given wrapper contains at least one matching element for the given selector. Matches against both host nodes like `<div>` and custom React components like `<MyComponent>`.
 
 ```js
 function User(props) {
@@ -242,7 +392,7 @@ Ways to use this API:
 expect().toContainMatchingElements(2, '.foo');
 ```
 
-Assert that the given wrapper contains a given number of matches for the given selector:
+Assert that the given wrapper contains a given number of matches for the given selector. Matches against both host nodes like `<div>` and custom React components like `<MyComponent>`.
 
 ```js
 function User(props) {
@@ -276,8 +426,12 @@ function Fixture() {
 const wrapper = mount(<Fixture />); // mount/render/shallow when applicable
 
 expect(wrapper).toContainMatchingElements(2, 'User');
-expect(wrapper).not.toContainMatchingElements(2, '.userTwo');
+expect(wrapper).toContainMatchingElements(2, 'span.user');
+expect(wrapper).not.toContainMatchingElements(2, 'span.userTwo');
 ```
+
+**Note:** The selector in the first assertion above is qualified using the tag name `span`. If it was not, `toContainMatchingElements` would fail because `wrapper.find('.user')` matches twice for both `User.user` and `span.user`, for a total of 4 matches. To only match host (DOM) nodes, use [`.toContainMatchingNodes(2, '.user')`](#tocontainmatchingnodes).
+
 
 #### `toContainExactlyOneMatchingElement()`
 
@@ -291,7 +445,7 @@ Ways to use this API:
 expect().toContainExactlyOneMatchingElement('.foo');
 ```
 
-Assert that the given wrapper contains exactly one match for the given selector:
+Assert that the given wrapper contains exactly one match for the given selector. Matches against both host nodes like `<div>` and custom React components like `<MyComponent>`.
 
 ```js
 function User(props) {
@@ -324,9 +478,11 @@ function Fixture() {
 
 const wrapper = mount(<Fixture />); // mount/render/shallow when applicable
 
-expect(wrapper).toContainExactlyOneMatchingElement('.userOne');
+expect(wrapper).toContainExactlyOneMatchingElement('span.userOne');
 expect(wrapper).not.toContainExactlyOneMatchingElement('User');
 ```
+
+**Note:** The selector in the first assertion above is qualified using the tag name `span`. If it was not, `toContainExactlyOneMatchingElement` would fail because `wrapper.find('.userOne')` matches for both `User.userOne` and `span.userOne`. To only match host (DOM) nodes, use [`.toContainExactlyOneMatchingNode('.userOne')`](#tocontainexactlyonematchingnode).
 
 #### `toContainReact()`
 
@@ -419,7 +575,7 @@ Ways to use this API:
 expect().toHaveDisplayName('div');
 ```
 
-Assert that the wrapper is of a certain tag type:
+Assert that the wrapper is of a certain tag type.
 
 ```js
 function Fixture() {
@@ -449,7 +605,7 @@ expect().toHaveHTML('<div>html</div>');
 ```
 
 
-Assert that the given wrapper has the provided html:
+Assert that the given wrapper has the provided html.
 
 > **Note** Quotations are normalized.
 
@@ -483,7 +639,7 @@ expect().toHaveProp('foo');
 expect().toHaveProp({foo: 'value'});
 ```
 
-Assert that the given wrapper has the provided propKey and associated value if specified:
+Assert that the given wrapper has the provided propKey and associated value if specified.
 
 ```js
 function User() { ... }
@@ -526,7 +682,7 @@ Ways to use this API:
 expect().toHaveRef('foo');
 ```
 
-Assert that the mounted wrapper has the provided ref:
+Assert that the mounted wrapper has the provided ref.
 
 ```js
 class Fixture extends React.Component {
@@ -559,7 +715,7 @@ expect().toHaveState('foo', 'bar');
 expect().toHaveState({ foo: 'bar' });
 ```
 
-Assert that the component has the provided stateKey and optional value if specified:
+Assert that the component has the provided stateKey and optional value if specified.
 
 ```js
 class Fixture extends React.Component {
@@ -598,7 +754,7 @@ expect().toHaveStyle('height', '100%');
 expect().toHaveStyle({ height: '100%' });
 ```
 
-Assert that the component has style of the provided key and value:
+Assert that the component has style of the provided key and value.
 
 ```js
 function Fixture() {
@@ -670,7 +826,7 @@ Ways to use this API:
 expect().toIncludeText('bar');
 ```
 
-Assert that the wrapper includes the provided text:
+Assert that the wrapper includes the provided text.
 
 ```js
 function Fixture() {
@@ -699,7 +855,7 @@ Ways to use this API:
 expect().toHaveValue('bar');
 ```
 
-Assert that the given wrapper has the provided `value`:
+Assert that the given wrapper has the provided `value`.
 
 ```js
 function Fixture() {
@@ -767,7 +923,7 @@ Ways to use this API:
 expect().toMatchSelector('.foo');
 ```
 
-Assert that the wrapper matches the provided `selector`:
+Assert that the wrapper matches the provided `selector`.
 
 ```js
 function Fixture() {
@@ -791,7 +947,7 @@ There is a special environment to simplify using enzyme with jest. Check it out 
 
 #### Usage with [Create React App](https://github.com/facebookincubator/create-react-app)
 
-If you are using Create React App, instead of adding to your `package.json` as above, you will need to add a `src/setupTests.js` file to your app, to import jest-enzyme:
+If you are using Create React App, instead of adding to your `package.json` as above, you will need to add a `src/setupTests.js` file to your app, to import jest-enzyme.
 
  ``` js
  // src/setupTests.js
@@ -802,13 +958,13 @@ If you are using Create React App, instead of adding to your `package.json` as a
 
 #### Usage with TypeScript
 
-As with Create React App, when using jest-enzyme with [TypeScript](http://typescriptlang.org/) and [ts-jest](https://github.com/kulshekhar/ts-jest), you'll need to add a `setupTests.ts` file to your app that explicitly imports jest-enzyme, and point the `setupFilesAfterEnv` field in your `package.json` file towards it:
+As with Create React App, when using jest-enzyme with [TypeScript](http://typescriptlang.org/) and [ts-jest](https://github.com/kulshekhar/ts-jest), you'll need to add a `setupTests.ts` file to your app that explicitly imports jest-enzyme, and point the `setupFilesAfterEnv` field in your `package.json` file towards it.
 
  ``` typescript
  // src/setupTests.ts
  import 'jest-enzyme';
  ```
- 
+
  ```js
 "jest": {
   "setupFilesAfterEnv": ["./src/setupTests.ts"],


### PR DESCRIPTION
This PR is a follow-on to https://github.com/FormidableLabs/enzyme-matchers/pull/336, until it is merged, this PR will also include changes from that PR.

This change adds three new matchers, similar to the existing `toContainMatchingElement` matchers, except that the new matchers only match against "host nodes". [Enzyme v3.1 added a `hostNodes` method](https://github.com/airbnb/enzyme/blob/master/CHANGELOG.md#310) that filters a result set to just "host nodes". According to [the `hostNodes` documentation](https://airbnb.io/enzyme/docs/api/ShallowWrapper/hostNodes.html), "host nodes" are "are HTML elements rather than custom React components, e.g. `<div>` versus `<MyComponent>`."