### PR TITLE
Make jest-environment-jsdom a peerDependency in jest-environment-enzyme

### DIFF
--- a/packages/jest-environment-enzyme/package.json
+++ b/packages/jest-environment-enzyme/package.json
@@ -43,12 +43,10 @@
   "peerDependencies": {
     "enzyme": "3.x",
     "jest": ">=22.0.0",
-    "react": "^0.13.0 || ^0.14.0 || ^15.0.0 || >=16.x"
+    "react": "^0.13.0 || ^0.14.0 || ^15.0.0 || >=16.x",
+    "jest-environment-jsdom": ">=22.0.0"
   },
   "devDependencies": {
     "cpy-cli": "^2.0.0"
-  },
-  "dependencies": {
-    "jest-environment-jsdom": "^25.2.0"
   }
 }


### PR DESCRIPTION
This increases flexibility for developers using this package. For example, I've been waiting for a couple months to upgrade to Jest 25 (see https://github.com/FormidableLabs/enzyme-matchers/issues/334). If this were a peer dependency, then I could have upgraded right away and it would have just automatically used the new version of `jest-environment-jsdom`.