### PR TITLE
Add jest-environment-jsdom to peer deps

### DIFF
--- a/packages/jest-environment-enzyme/package.json
+++ b/packages/jest-environment-enzyme/package.json
@@ -43,12 +43,11 @@
   "peerDependencies": {
     "enzyme": "3.x",
     "jest": ">=22.0.0",
-    "react": "^0.13.0 || ^0.14.0 || ^15.0.0 || >=16.x"
+    "react": "^0.13.0 || ^0.14.0 || ^15.0.0 || >=16.x",
+    "jest-environment-jsdom": "^22 || ^23 || ^24 || ^25 || ^26"
   },
   "devDependencies": {
-    "cpy-cli": "^2.0.0"
-  },
-  "dependencies": {
+    "cpy-cli": "^2.0.0",
     "jest-environment-jsdom": "^25.2.0"
   }
 }


### PR DESCRIPTION
This is blocking a jest upgrade we're doing, since multiple copies of the jest-environment-jsdom is producing errors in our tests.

The other PR(https://github.com/FormidableLabs/enzyme-matchers/pull/343) for this seems stalled out.