### PR TITLE
Compatibility with future jasmine versions

### DIFF
--- a/packages/jasmine-enzyme/spec/customEqualityTesters--spec.js
+++ b/packages/jasmine-enzyme/spec/customEqualityTesters--spec.js
@@ -1,0 +1,67 @@
+/* eslint-disable global-require */
+'use strict'; // eslint-disable-line
+
+const { shallow } = require('enzyme');
+const React = require('react');
+const jasmineEnzyme = require('../lib/index.js');
+
+describe('Support for Jasmine custom equality testers', () => {
+  function createMatcherFactory() {
+    spyOn(jasmine, 'addMatchers');
+    jasmineEnzyme();
+    const addMatchersArgs = jasmine.addMatchers.calls
+      .allArgs()
+      .filter(args => args[0].toHaveState)[0];
+    return addMatchersArgs[0].toHaveState;
+  }
+
+  it('works with Jasmine <3.6', () => {
+    const matcherFactory = createMatcherFactory();
+    const Fixture = require('./fixtures/toHaveState.fixture');
+    const wrapper = shallow(React.createElement(Fixture));
+    const util = {
+      equals: (a, b, testers) => testers[0](a, b),
+    };
+    const customEqualityTesters = [(a, b) => a.toString() === b.toString()];
+    const matcher = matcherFactory(util, customEqualityTesters);
+
+    const result = matcher.compare(wrapper, 'foo', 'false');
+    expect(result.pass).toEqual(true);
+  });
+
+  it('works with Jasmine >= 3.6 without triggering deprecation warnings', () => {
+    const matcherFactory = createMatcherFactory();
+    const Fixture = require('./fixtures/toHaveState.fixture');
+    const wrapper = shallow(React.createElement(Fixture));
+    const customEqualityTesters = [(a, b) => a.toString() === b.toString()];
+    customEqualityTesters.deprecated = true;
+    const util = jasmine.createSpyObj('matchersUtil', ['equals']);
+    util.equals.and.callFake((a, b) => customEqualityTesters[0](a, b));
+    const matcher = matcherFactory(util, customEqualityTesters);
+
+    const result = matcher.compare(wrapper, 'foo', 'false');
+    expect(result.pass).toEqual(true);
+    expect(util.equals).toHaveBeenCalled();
+
+    // Make sure we don't trigger any deprecation warnings
+    expect(matcherFactory.length).toBeLessThan(2);
+    expect(util.equals).not.toHaveBeenCalledWith(
+      jasmine.anything(),
+      jasmine.anything(),
+      customEqualityTesters
+    );
+  });
+
+  it('works if Jasmine does not pass customEqualityTesters', () => {
+    const matcherFactory = createMatcherFactory();
+    const Fixture = require('./fixtures/toHaveState.fixture');
+    const wrapper = shallow(React.createElement(Fixture));
+    const util = {
+      equals: () => true,
+    };
+    const matcher = matcherFactory(util);
+
+    const result = matcher.compare(wrapper, 'foo', 'false');
+    expect(result.pass).toEqual(true);
+  });
+});

--- a/packages/jasmine-enzyme/src/index.js
+++ b/packages/jasmine-enzyme/src/index.js
@@ -23,8 +23,11 @@ function jasmineEnzyme(): void {
 
   const toJasmineMatcher = (matcherFn: Function) => (
     util: Object,
-    customEqualityTesters: Object
+    ...extraArgs
   ) => {
+    const customEqualityTesters =
+      extraArgs[0] && !extraArgs[0].deprecated ? extraArgs[0] : undefined;
+
     // Convert the equals util from jasmine to share the same interface as jest
     const equals = (actual, expected) =>
       util.equals(actual, expected, customEqualityTesters);


### PR DESCRIPTION
Prior to Jasmine 3.6, matchers that wanted to support custom equality testers had to accept them as an argument  to the matcher factory and pass them to MatchersUtil#equals and MatchersUtil#contains. That's not required beginning with 3.6. It'll produce a deprecation warning in 3.99 and fail in 4.0. This PR updates jasmine-enzyme to be compatible with the planned changes in Jasmine 3.99 and 4.0, while maintaining compatibility with older versions.

Additional context:
https://jasmine.github.io/tutorials/upgrading_to_Jasmine_4.0#matchers-cet

I've tested this by running a usage of toHaveState that relies on custom equality testers against the following versions of the `jasmine` package:
`3.5.0`
`github:jasmine/jasmine-npm#3.99`
`github:jasmine/jasmine-npm#4.0`